### PR TITLE
Update README with detailed configuration and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ Once installed, you can use `cai` like a normal Git command:
 git cai
 ```
 
-`cai` will create a  
+`cai` automatically creates a configuration file at: `~/.config/cai/token.yml`
+This file stores your OpenAI API key, which is used every time you run `git cai`.
+If a `cai_config.yml` file exists in the root of your repository, `cai` will use the settings defined there. Otherwise, it falls back to default settings, which are automatically created in the same directory as `token.yml` if they don’t already exist.  
+Currently, the only configurable options are:
+
+- OpenAI model
+- Temperature
+
+`cai` uses Git’s `diff` output as input for generating commit messages.  
+To exclude specific files or directories from being included in the generated commit message, create a `.caiignore` file in the root of your repository. This file works like a `.gitignore`.  
+
+- Files listed in `.gitignore` are **always excluded**.  
+- `.caiignore` is only needed for files that are tracked by Git but should **not** be included in the commit message.
 
 <h2 id="license-section">License</h2>
 This project is licensed under the MIT License.


### PR DESCRIPTION
- Added information about automatic creation and location of the `token.yml` configuration file.
- Explained usage of `cai_config.yml` for repository-specific settings and fallback to default settings.
- Listed configurable options (OpenAI model, temperature).
- Clarified how `cai` uses Git diff output and how to exclude files using `.caiignore`.
- Noted that files in `.gitignore` are always excluded from commit message generation.