### PR TITLE
Update commit message prompt to handle sensitive information

### DIFF
--- a/src/git_cai_cli/core/llm.py
+++ b/src/git_cai_cli/core/llm.py
@@ -48,6 +48,8 @@ class CommitMessageGenerator:
             "summarizing the provided git diff changes. "
             "Keep the message clear and focused on what was changed and why. "
             "Always include a headline, followed by a bullet-point list of changes."
+            "Should you observe any sensitive information in the diff, print 'SENSITIVE INFORMATION DETECTED' and show what was detected, the file where and the line number."
+            "But even if you see sensitive information, still generate the commit message."
         )
 
     def generate_openai(self, git_diff: str, openai_cls: Type[Any] = OpenAI) -> str:


### PR DESCRIPTION
- Added instructions to the commit message prompt to detect and report sensitive information in diffs
- Specified that sensitive information should be shown with details (content, file, line number)
- Clarified that a commit message should still be generated even if sensitive information is detected