### PR TITLE
✨ Enable context in squash mode

### DIFF
--- a/docs/git-cai.txt
+++ b/docs/git-cai.txt
@@ -399,18 +399,19 @@ git cai -v
 
 -x, --context CONTEXT::
 Provide extra context for the LLM to consider when generating the commit
-message. The context string is appended to the diff before sending it to
-the provider. This is useful for including information that is not visible
-in the diff itself, such as a ticket number, the reason for a change, or
-a link to an issue.
+message. The context string is appended to the diff (or commit history in squash
+mode) before sending it to the provider. This is useful for including information
+that is not visible in the diff itself, such as a ticket number, the reason for
+a change, or a link to an issue.
 +
-Can be combined with any commit-generating mode (`COMMIT` or `AMEND`).
-Cannot be used with `--list`, `--update`, or `--squash`.
+Can be combined with any commit-generating mode (`COMMIT`, `AMEND`, or `SQUASH`).
+Cannot be used with `--list` or `--update`.
 +
 ----
 git cai -x "Fixes JIRA-1234"
 git cai -x "Performance optimisation for the search endpoint"
 git cai -A -x "Reword after code review feedback"
+git cai --squash -x "Resolves JIRA-99"
 ----
 
 LIST TYPES

--- a/docs/man/git-cai.1
+++ b/docs/man/git-cai.1
@@ -2,12 +2,12 @@
 .\"     Title: git-cai
 .\"    Author: Thorsten Foltz
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-04-17
+.\"      Date: 2026-04-23
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "GIT\-CAI" "1" "2026-04-17" "\ \&" "\ \&"
+.TH "GIT\-CAI" "1" "2026-04-23" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -668,13 +668,13 @@ git cai \-v
 \-x, \-\-context CONTEXT
 .RS 4
 Provide extra context for the LLM to consider when generating the commit
-message. The context string is appended to the diff before sending it to
-the provider. This is useful for including information that is not visible
-in the diff itself, such as a ticket number, the reason for a change, or
-a link to an issue.
+message. The context string is appended to the diff (or commit history in squash
+mode) before sending it to the provider. This is useful for including information
+that is not visible in the diff itself, such as a ticket number, the reason for
+a change, or a link to an issue.
 .sp
-Can be combined with any commit\-generating mode (\f(CRCOMMIT\fP or \f(CRAMEND\fP).
-Cannot be used with \f(CR\-\-list\fP, \f(CR\-\-update\fP, or \f(CR\-\-squash\fP.
+Can be combined with any commit\-generating mode (\f(CRCOMMIT\fP, \f(CRAMEND\fP, or \f(CRSQUASH\fP).
+Cannot be used with \f(CR\-\-list\fP or \f(CR\-\-update\fP.
 .sp
 .if n .RS 4
 .nf
@@ -682,6 +682,7 @@ Cannot be used with \f(CR\-\-list\fP, \f(CR\-\-update\fP, or \f(CR\-\-squash\fP.
 git cai \-x "Fixes JIRA\-1234"
 git cai \-x "Performance optimisation for the search endpoint"
 git cai \-A \-x "Reword after code review feedback"
+git cai \-\-squash \-x "Resolves JIRA\-99"
 .fam
 .fi
 .if n .RE

--- a/src/git_cai_cli/cli/modes.py
+++ b/src/git_cai_cli/cli/modes.py
@@ -87,9 +87,9 @@ def validate_options(
         )
         raise typer.Exit(code=1)
 
-    if context and mode not in (Mode.COMMIT, Mode.AMEND):
+    if context and mode not in (Mode.COMMIT, Mode.AMEND, Mode.SQUASH):
         typer.echo(
-            "Error: --context cannot be used with --list, --update, or --squash.",
+            "Error: --context cannot be used with --list or --update.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/git_cai_cli/core/llm.py
+++ b/src/git_cai_cli/core/llm.py
@@ -168,13 +168,23 @@ class CommitMessageGenerator:
 
         return self._dispatch_generate(content=content, system_prompt=prompt)
 
-    def summarize_commit_history(self, commit_messages: str) -> str:
+    def summarize_commit_history(
+        self, commit_messages: str, context: str | None = None
+    ) -> str:
         """
         Summarize multiple commit messages into one high-level commit message.
         """
         prompt = self._build_squash_prompt()
         log.debug("Squash system prompt preview: %r", prompt[:400])
-        return self._dispatch_generate(content=commit_messages, system_prompt=prompt)
+
+        content = commit_messages
+        if context:
+            content = (
+                f"{commit_messages}\n\n"
+                f"--- Additional context from the author ---\n{context}"
+            )
+
+        return self._dispatch_generate(content=content, system_prompt=prompt)
 
     def _emoji_instruction(self) -> str:
         """

--- a/src/git_cai_cli/core/options.py
+++ b/src/git_cai_cli/core/options.py
@@ -364,6 +364,7 @@ git cai -l style
         model_override: str | None = None,
         time_flag: bool = False,
         squash_arg: str | None = None,
+        context: str | None = None,
     ) -> None:
         """
         Squash commits on the current branch and summarize them.
@@ -373,6 +374,7 @@ git cai -l style
             model_override=model_override,
             time_flag=time_flag,
             squash_arg=squash_arg,
+            context=context,
         )
 
     def stage_tracked_files(self) -> None:

--- a/src/git_cai_cli/core/squash.py
+++ b/src/git_cai_cli/core/squash.py
@@ -184,6 +184,7 @@ def squash_branch(
     model_override: str | None = None,
     time_flag: bool = False,
     squash_arg: str | None = None,
+    context: str | None = None,
 ) -> None:
     """
     Squash commits in the current branch into a single commit with an LLM-generated message.
@@ -192,6 +193,7 @@ def squash_branch(
         squash_arg: Optional. A number (squash last N commits) or a commit hash
                     (squash up to and including that commit). If None, squash all
                     commits since the branch diverged.
+        context: Optional. Extra context for the LLM (e.g. ticket number, reason for change).
     """
     repo_root = find_git_root()
     if not repo_root:
@@ -297,7 +299,9 @@ def squash_branch(
 
         try:
             with Spinner("Summarizing commit history"):
-                summary_message = generator.summarize_commit_history(commit_log)
+                summary_message = generator.summarize_commit_history(
+                    commit_log, context=context
+                )
         except ValueError as e:
             log.error("%s", e)
             sys.exit(1)

--- a/src/git_cai_cli/main.py
+++ b/src/git_cai_cli/main.py
@@ -111,6 +111,7 @@ def run(
             model_override=model_override,
             time_flag=time_flag,
             squash_arg=list_arg,
+            context=context,
         )
         return
 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -973,6 +973,48 @@ def test_generate_with_empty_context_passes_diff_only(generator):
     assert content == "diff output"
 
 
+def test_summarize_appends_context_to_commit_messages(generator):
+    """summarize_commit_history() with context appends it after the messages."""
+    with patch.object(generator, "_dispatch_generate", return_value="summary") as mock:
+        generator.summarize_commit_history("commit messages", context="Closes #42")
+
+    call_args = mock.call_args
+    content = call_args[1]["content"] if "content" in call_args[1] else call_args[0][0]
+    assert "commit messages" in content
+    assert "--- Additional context from the author ---" in content
+    assert "Closes #42" in content
+
+
+def test_summarize_without_context_passes_messages_only(generator):
+    """summarize_commit_history() without context passes only the messages."""
+    with patch.object(generator, "_dispatch_generate", return_value="summary") as mock:
+        generator.summarize_commit_history("commit messages")
+
+    call_args = mock.call_args
+    content = call_args[1]["content"] if "content" in call_args[1] else call_args[0][0]
+    assert content == "commit messages"
+
+
+def test_summarize_with_none_context_passes_messages_only(generator):
+    """summarize_commit_history() with None context should pass only the messages."""
+    with patch.object(generator, "_dispatch_generate", return_value="summary") as mock:
+        generator.summarize_commit_history("commit messages", context=None)
+
+    call_args = mock.call_args
+    content = call_args[1]["content"] if "content" in call_args[1] else call_args[0][0]
+    assert content == "commit messages"
+
+
+def test_summarize_with_empty_context_passes_messages_only(generator):
+    """summarize_commit_history() with empty string context should pass only the messages."""
+    with patch.object(generator, "_dispatch_generate", return_value="summary") as mock:
+        generator.summarize_commit_history("commit messages", context="")
+
+    call_args = mock.call_args
+    content = call_args[1]["content"] if "content" in call_args[1] else call_args[0][0]
+    assert content == "commit messages"
+
+
 # ---- timeout resolution ----
 
 

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -263,8 +263,8 @@ def test_context_rejected_with_list_mode(capsys):
         )
     captured = capsys.readouterr()
     assert (
-        "cannot be used with --list, --update, or --squash" in captured.out
-        or "cannot be used with --list, --update, or --squash" in captured.err
+        "cannot be used with --list or --update" in captured.out
+        or "cannot be used with --list or --update" in captured.err
     )
     assert exc.value.exit_code == 1
 
@@ -282,29 +282,22 @@ def test_context_rejected_with_update_mode(capsys):
         )
     captured = capsys.readouterr()
     assert (
-        "cannot be used with --list, --update, or --squash" in captured.out
-        or "cannot be used with --list, --update, or --squash" in captured.err
+        "cannot be used with --list or --update" in captured.out
+        or "cannot be used with --list or --update" in captured.err
     )
     assert exc.value.exit_code == 1
 
 
-def test_context_rejected_with_squash_mode(capsys):
-    """--context cannot be used with --squash."""
-    with pytest.raises(typer.Exit) as exc:
-        modes.validate_options(
-            mode=Mode.SQUASH,
-            stage_tracked=False,
-            enable_debug=False,
-            help_flag=False,
-            version_flag=False,
-            context="some context",
-        )
-    captured = capsys.readouterr()
-    assert (
-        "cannot be used with --list, --update, or --squash" in captured.out
-        or "cannot be used with --list, --update, or --squash" in captured.err
+def test_context_allowed_with_squash_mode():
+    """--context is allowed with SQUASH mode."""
+    modes.validate_options(
+        mode=Mode.SQUASH,
+        stage_tracked=False,
+        enable_debug=False,
+        help_flag=False,
+        version_flag=False,
+        context="Closes #42",
     )
-    assert exc.value.exit_code == 1
 
 
 def test_context_allowed_with_commit_mode():

--- a/tests/unit/test_squash.py
+++ b/tests/unit/test_squash.py
@@ -383,3 +383,31 @@ def test_squash_branch_with_squash_arg(mock_repo_root, mock_generator) -> None:
         ],
         any_order=False,
     )
+
+
+def test_squash_branch_passes_context_to_generator(
+    mock_generator, mock_repo_root, clean_git_state
+):
+    """squash_branch() with context passes it to summarize_commit_history()."""
+
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("subprocess.check_output", side_effect=clean_git_state),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.squash.CommitMessageGenerator",
+            return_value=mock_generator,
+        ),
+        patch("git_cai_cli.core.squash.get_git_editor", return_value="true"),
+        patch("git_cai_cli.core.squash.sha256_of_file", side_effect=["a", "b"]),
+        patch("subprocess.run", return_value=MagicMock(returncode=0)),
+        patch("git_cai_cli.core.squash._has_upstream", return_value=False),
+        patch("git_cai_cli.core.squash._has_commits", return_value=True),
+    ):
+        squash_branch(context="Closes #42")
+
+    call_args = mock_generator.summarize_commit_history.call_args
+    assert call_args[1].get("context") == "Closes #42"


### PR DESCRIPTION
- 📝 Allow optional context in squash-generated commit messages so authors can include ticket references and rationale when summarizing history
- 🔄 Carry context through the squash flow to keep message generation consistent with commit and amend behavior
- ✅ Update validation, tests, and documentation to reflect the new support and clarify where context remains unavailable
- 🧹 Reformat long signatures and calls to improve readability and keep the updated code aligned with project style expectations