### PR TITLE
✨ Refine PR generation defaults and tooling

### DIFF
--- a/.linters/.flake8
+++ b/.linters/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-#extend-ignore = E501, F821
+extend-ignore = E203
 exclude =
     test_copy_files_fsb.py,
     __pycache__

--- a/.linters/.pylintrc
+++ b/.linters/.pylintrc
@@ -41,7 +41,7 @@ include-naming-hint=yes                    # Suggest the expected format when na
 max-line-length=256                        # Maximum line length
 indent-string='    '                       # Use 4 spaces per indentation level
 indent-after-paren=4                       # Hanging indent size
-max-module-lines=1000                      # Max lines per module before warning
+max-module-lines=2000                      # Max lines per module before warning
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
                                            # Ignore long lines if they’re URLs or comments
 expected-line-ending-format=LF             # Require LF line endings

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -2,4 +2,5 @@
 cli.py
 config.py
 squash.py
+pr.py
 release_aur.yml

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Currently supported providers:
 - Conventional Commits format support
 - Change configuration from the command line
 - Optional commit squashing with automatic summary generation (all, last N, or up to a specific commit)
+- Pull Request description generator (`--PR`) that summarizes the commits between the current branch and its base
 - List providers, models, active config, and file paths
 - Token usage logging for API calls
 - Branch name as LLM context
@@ -204,6 +205,9 @@ git cai -g
 - `conventional` – use Conventional Commits format
 - `token_logging` – log token usage after each LLM call
 - `measure_time` – log generation time
+- `pr_to_file` – when `--PR` is used, write the generated description to a Markdown file in the repo root instead of stdout (default `false`)
+- `pr_file_name` – filename used when `pr_to_file` is `true` (default `PR_DESCRIPTION.md`)
+- `pr_prompt_file` – optional path to a custom Markdown prompt for `--PR` (falls back to `~/.config/cai/pr_prompt.md`, then a built-in default)
 
 ---
 
@@ -227,6 +231,8 @@ In addition to `git cai`, the following options are available:
 - `-m`, `--model` – override the model for this invocation (requires `-P`)
 - `-p`, `--generate-prompts` – generate default `commit_prompt.md` and `squash_prompt.md` in the current directory (for customization)
 - `-P`, `--provider` – override the LLM provider for this invocation
+- `-r`, `--PR` – generate a Pull Request description from the commits between the current branch and its base (prints to stdout by default; set `pr_to_file=true` to write a Markdown file)
+- `--base` `BRANCH` – explicit base branch for `--PR` (overrides auto-detection: `origin/HEAD` → `main` → `master`)
 - `-S`, `--set` – set a config value (`key=value`) in repo config (requires existing repo config)
 - `-s`, `--squash` `[N|HASH]` – squash commits on the current branch and summarize them. Without argument: squash all since branch checkout. With a number: squash the last N commits. With a commit hash: squash up to and including that commit
 - `-T`, `--timeout` `SECONDS` – HTTP timeout for this invocation (overrides config)
@@ -287,6 +293,39 @@ Persist the default:
 ```sh
 git cai -S full_files=true
 ```
+
+### Pull Request descriptions
+
+`-r` / `--PR` generates a Markdown Pull Request description from the commits
+between the current branch and its base branch. The output has two sections —
+`## Summary` (bullet list following the same best practices as commit messages:
+imperative mood, capitalized, no trailing period, 72-char wrap) and
+`## Test plan` (a checklist a reviewer can run).
+
+This mode never modifies git state — no commit, no reset, no force push.
+
+```sh
+git cai -r                      # print to stdout (default)
+git cai --PR                    # long form
+git cai -r --base develop       # explicit base branch
+git cai -r -x "Closes JIRA-1234"  # add extra context
+```
+
+The base branch is auto-detected in this order: `origin/HEAD`, then local
+`main`, then local `master`. Use `--base` for repositories with non-standard
+layouts or no `origin/HEAD`.
+
+By default the description is printed to stdout. To write it to a file in the
+repository root instead, set `pr_to_file: true`:
+
+```sh
+git cai -S pr_to_file=true
+git cai -S pr_file_name=PR.md   # optional: change the filename
+git cai -r                       # writes ./PR.md (or PR_DESCRIPTION.md by default)
+```
+
+Configuration follows the usual precedence: repo `cai_config.yml` wins,
+otherwise `~/.config/cai/cai_config.yml`, otherwise the built-in defaults.
 
 ### Changing configuration from the CLI
 

--- a/cai_config.yml
+++ b/cai_config.yml
@@ -12,6 +12,9 @@ token_logging: true
 measure_time: true
 timeout: 30
 full_files: false
+pr_to_file: false
+pr_file_name: PR_DESCRIPTION.md
+pr_prompt_file: "/home/thorsten/.config/cai/pr_prompt.md"
 anthropic:
   model: claude-haiku-4-5
   temperature: 0

--- a/docs/git-cai.txt
+++ b/docs/git-cai.txt
@@ -20,6 +20,7 @@ SYNOPSIS
          --list [config|editor|language|model|path|provider|style]]
         [-m MODEL | --model MODEL]
         [-P PROVIDER | --provider PROVIDER] [-p | --generate-prompts]
+        [-r | --PR] [--base BRANCH]
         [-S KEY=VALUE | --set KEY=VALUE]
         [-s [N|HASH] | --squash [N|HASH]]
         [-T SECONDS | --timeout SECONDS]
@@ -299,6 +300,48 @@ overwrites.
 git cai -p
 ----
 
+-r, --PR::
+Generate a Pull Request description summarizing the commits between the
+current branch and its base branch. git-cai collects the commit messages
+and the list of files changed since the branch diverged, sends them to
+the configured LLM, and produces a Markdown description with `## Summary`
+and `## Test plan` sections.
++
+This mode never modifies git state: no commit, no reset, no force push.
++
+By default the generated description is printed to stdout. To write it to
+a file in the repository root instead, set `pr_to_file: true` in
+`cai_config.yml`. The filename defaults to `PR_DESCRIPTION.md` and can be
+changed via `pr_file_name`. Configuration follows the same precedence as
+every other key (repository config wins; otherwise home config; otherwise
+built-in defaults).
++
+The base branch is auto-detected in this order: `origin/HEAD`, then local
+`main`, then local `master`. Use `--base` to override.
++
+Cannot be combined with `--amend`, `--list`, `--squash`, or `--update`.
+Can be combined with `--context` to inject extra context (e.g. a ticket
+number or reviewer ask).
++
+----
+git cai -r
+git cai --PR
+git cai -r --base develop
+git cai -r -x "Closes JIRA-1234"
+----
+
+--base BRANCH::
+Explicit base branch for `--PR`. Overrides the auto-detection chain
+(`origin/HEAD` -> `main` -> `master`). Useful for repositories whose base
+branch is not `main`/`master` or that lack `origin/HEAD`.
++
+Only meaningful in combination with `--PR` (`-r`).
++
+----
+git cai -r --base develop
+git cai -r --base release/1.x
+----
+
 -S, --set KEY=VALUE::
 Set a configuration value in the repository config (`cai_config.yml` in the
 repository root). Requires an existing repo config; if none is found, an
@@ -399,12 +442,13 @@ git cai -v
 
 -x, --context CONTEXT::
 Provide extra context for the LLM to consider when generating the commit
-message. The context string is appended to the diff (or commit history in squash
-mode) before sending it to the provider. This is useful for including information
-that is not visible in the diff itself, such as a ticket number, the reason for
-a change, or a link to an issue.
+message. The context string is appended to the diff (or commit history in
+squash mode, or the commit list in PR mode) before sending it to the
+provider. This is useful for including information that is not visible in
+the diff itself, such as a ticket number, the reason for a change, or a
+link to an issue.
 +
-Can be combined with any commit-generating mode (`COMMIT`, `AMEND`, or `SQUASH`).
+Can be combined with `COMMIT`, `AMEND`, `SQUASH`, or `PR` modes.
 Cannot be used with `--list` or `--update`.
 +
 ----
@@ -412,6 +456,7 @@ git cai -x "Fixes JIRA-1234"
 git cai -x "Performance optimisation for the search endpoint"
 git cai -A -x "Reword after code review feedback"
 git cai --squash -x "Resolves JIRA-99"
+git cai -r -x "Closes JIRA-1234"
 ----
 
 LIST TYPES
@@ -622,6 +667,16 @@ Available configuration keys:
 - `timeout` -- HTTP timeout in seconds for remote LLM calls (default `30`)
 - `full_files` -- send full working-tree contents of staged files alongside
   the diff (`true`/`false`, default `false`)
+- `pr_to_file` -- when running `--PR`, write the generated PR description
+  to a Markdown file in the repository root instead of printing it to
+  stdout (`true`/`false`, default `false`)
+- `pr_file_name` -- filename used when `pr_to_file` is `true` (default
+  `PR_DESCRIPTION.md`). The file is written in the repository root and
+  overwritten on each run.
+- `pr_prompt_file` -- path to a custom Markdown prompt file used by
+  `--PR`. Follows the same fallback chain as `prompt_file` /
+  `squash_prompt_file`: configured path -> `~/.config/cai/pr_prompt.md` ->
+  built-in fallback.
 - `<provider>.model` -- model name for a specific provider
 - `<provider>.temperature` -- temperature for a specific provider
 - `anthropic.max_tokens` -- upper bound on Anthropic response tokens
@@ -718,6 +773,35 @@ Squash all commits down to and including a specific commit:
 
 ----
 git cai -s a1b2c3d
+----
+
+Generate a Pull Request description from the current branch (prints to
+stdout):
+
+----
+git cai -r
+git cai --PR
+----
+
+Generate a PR description against an explicit base branch:
+
+----
+git cai -r --base develop
+----
+
+Write the PR description to a file in the repository root (set once in
+`cai_config.yml`, then run normally):
+
+----
+git cai -S pr_to_file=true
+git cai -S pr_file_name=PR.md
+git cai -r
+----
+
+Generate a PR description with extra context:
+
+----
+git cai -r -x "Closes JIRA-1234"
 ----
 
 Show supported styles, languages, or editors:

--- a/docs/man/git-cai.1
+++ b/docs/man/git-cai.1
@@ -2,12 +2,12 @@
 .\"     Title: git-cai
 .\"    Author: Thorsten Foltz
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-04-23
+.\"      Date: 2026-04-27
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "GIT\-CAI" "1" "2026-04-23" "\ \&" "\ \&"
+.TH "GIT\-CAI" "1" "2026-04-27" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -42,6 +42,7 @@ git-cai \- AI\-powered commit message generator
          \-\-list [config|editor|language|model|path|provider|style]]
         [\-m MODEL | \-\-model MODEL]
         [\-P PROVIDER | \-\-provider PROVIDER] [\-p | \-\-generate\-prompts]
+        [\-r | \-\-PR] [\-\-base BRANCH]
         [\-S KEY=VALUE | \-\-set KEY=VALUE]
         [\-s [N|HASH] | \-\-squash [N|HASH]]
         [\-T SECONDS | \-\-timeout SECONDS]
@@ -523,6 +524,60 @@ git cai \-p
 .if n .RE
 .RE
 .sp
+\-r, \-\-PR
+.RS 4
+Generate a Pull Request description summarizing the commits between the
+current branch and its base branch. git\-cai collects the commit messages
+and the list of files changed since the branch diverged, sends them to
+the configured LLM, and produces a Markdown description with \f(CR## Summary\fP
+and \f(CR## Test plan\fP sections.
+.sp
+This mode never modifies git state: no commit, no reset, no force push.
+.sp
+By default the generated description is printed to stdout. To write it to
+a file in the repository root instead, set \f(CRpr_to_file: true\fP in
+\f(CRcai_config.yml\fP. The filename defaults to \f(CRPR_DESCRIPTION.md\fP and can be
+changed via \f(CRpr_file_name\fP. Configuration follows the same precedence as
+every other key (repository config wins; otherwise home config; otherwise
+built\-in defaults).
+.sp
+The base branch is auto\-detected in this order: \f(CRorigin/HEAD\fP, then local
+\f(CRmain\fP, then local \f(CRmaster\fP. Use \f(CR\-\-base\fP to override.
+.sp
+Cannot be combined with \f(CR\-\-amend\fP, \f(CR\-\-list\fP, \f(CR\-\-squash\fP, or \f(CR\-\-update\fP.
+Can be combined with \f(CR\-\-context\fP to inject extra context (e.g. a ticket
+number or reviewer ask).
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-r
+git cai \-\-PR
+git cai \-r \-\-base develop
+git cai \-r \-x "Closes JIRA\-1234"
+.fam
+.fi
+.if n .RE
+.RE
+.sp
+\-\-base BRANCH
+.RS 4
+Explicit base branch for \f(CR\-\-PR\fP. Overrides the auto\-detection chain
+(\f(CRorigin/HEAD\fP \(-> \f(CRmain\fP \(-> \f(CRmaster\fP). Useful for repositories whose base
+branch is not \f(CRmain\fP/\f(CRmaster\fP or that lack \f(CRorigin/HEAD\fP.
+.sp
+Only meaningful in combination with \f(CR\-\-PR\fP (\f(CR\-r\fP).
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-r \-\-base develop
+git cai \-r \-\-base release/1.x
+.fam
+.fi
+.if n .RE
+.RE
+.sp
 \-S, \-\-set KEY=VALUE
 .RS 4
 Set a configuration value in the repository config (\f(CRcai_config.yml\fP in the
@@ -668,12 +723,13 @@ git cai \-v
 \-x, \-\-context CONTEXT
 .RS 4
 Provide extra context for the LLM to consider when generating the commit
-message. The context string is appended to the diff (or commit history in squash
-mode) before sending it to the provider. This is useful for including information
-that is not visible in the diff itself, such as a ticket number, the reason for
-a change, or a link to an issue.
+message. The context string is appended to the diff (or commit history in
+squash mode, or the commit list in PR mode) before sending it to the
+provider. This is useful for including information that is not visible in
+the diff itself, such as a ticket number, the reason for a change, or a
+link to an issue.
 .sp
-Can be combined with any commit\-generating mode (\f(CRCOMMIT\fP, \f(CRAMEND\fP, or \f(CRSQUASH\fP).
+Can be combined with \f(CRCOMMIT\fP, \f(CRAMEND\fP, \f(CRSQUASH\fP, or \f(CRPR\fP modes.
 Cannot be used with \f(CR\-\-list\fP or \f(CR\-\-update\fP.
 .sp
 .if n .RS 4
@@ -683,6 +739,7 @@ git cai \-x "Fixes JIRA\-1234"
 git cai \-x "Performance optimisation for the search endpoint"
 git cai \-A \-x "Reword after code review feedback"
 git cai \-\-squash \-x "Resolves JIRA\-99"
+git cai \-r \-x "Closes JIRA\-1234"
 .fam
 .fi
 .if n .RE
@@ -1131,6 +1188,46 @@ the diff (\f(CRtrue\fP/\f(CRfalse\fP, default \f(CRfalse\fP)
 .  sp -1
 .  IP \(bu 2.3
 .\}
+\f(CRpr_to_file\fP \(em when running \f(CR\-\-PR\fP, write the generated PR description
+to a Markdown file in the repository root instead of printing it to
+stdout (\f(CRtrue\fP/\f(CRfalse\fP, default \f(CRfalse\fP)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\f(CRpr_file_name\fP \(em filename used when \f(CRpr_to_file\fP is \f(CRtrue\fP (default
+\f(CRPR_DESCRIPTION.md\fP). The file is written in the repository root and
+overwritten on each run.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\f(CRpr_prompt_file\fP \(em path to a custom Markdown prompt file used by
+\f(CR\-\-PR\fP. Follows the same fallback chain as \f(CRprompt_file\fP /
+\f(CRsquash_prompt_file\fP: configured path \(-> \f(CR~/.config/cai/pr_prompt.md\fP \(->
+built\-in fallback.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
 \f(CR<provider>.model\fP \(em model name for a specific provider
 .RE
 .sp
@@ -1318,6 +1415,51 @@ Squash all commits down to and including a specific commit:
 .nf
 .fam C
 git cai \-s a1b2c3d
+.fam
+.fi
+.if n .RE
+.sp
+Generate a Pull Request description from the current branch (prints to
+stdout):
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-r
+git cai \-\-PR
+.fam
+.fi
+.if n .RE
+.sp
+Generate a PR description against an explicit base branch:
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-r \-\-base develop
+.fam
+.fi
+.if n .RE
+.sp
+Write the PR description to a file in the repository root (set once in
+\f(CRcai_config.yml\fP, then run normally):
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-S pr_to_file=true
+git cai \-S pr_file_name=PR.md
+git cai \-r
+.fam
+.fi
+.if n .RE
+.sp
+Generate a PR description with extra context:
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-r \-x "Closes JIRA\-1234"
 .fam
 .fi
 .if n .RE

--- a/src/git_cai_cli/cli/cli.py
+++ b/src/git_cai_cli/cli/cli.py
@@ -78,6 +78,17 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
     squash: bool = typer.Option(
         False, "--squash", "-s", help="Squash commits on this branch"
     ),
+    pr: bool = typer.Option(
+        False,
+        "--PR",
+        "-r",
+        help="Generate a Pull Request description from the commits on this branch",
+    ),
+    base: str = typer.Option(
+        None,
+        "--base",
+        help="Explicit base branch for --PR (overrides auto-detection)",
+    ),
     update: bool = typer.Option(False, "--update", "-u", help="Check for updates"),
     set_config: str = typer.Option(
         None,
@@ -143,7 +154,13 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
         do_install()
         raise typer.Exit()
 
-    mode = resolve_mode(amend=amend, list_flag=list_flag, squash=squash, update=update)
+    mode = resolve_mode(
+        amend=amend,
+        list_flag=list_flag,
+        pr=pr,
+        squash=squash,
+        update=update,
+    )
 
     validate_options(
         mode=mode,
@@ -180,8 +197,8 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
         try:
             manager.generate_prompts_here()
             typer.echo(
-                "commit_prompt.md, squash_prompt.md, and full_files_prompt.md "
-                "created in current directory."
+                "commit_prompt.md, squash_prompt.md, full_files_prompt.md, "
+                "and pr_prompt.md created in current directory."
             )
         except RuntimeError as e:
             typer.echo(f"Error: {e}", err=True)
@@ -228,6 +245,7 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
         timeout_override=timeout,
         full_files_override=full_files,
         files_override=files,
+        base_override=base,
     )
 
 

--- a/src/git_cai_cli/cli/helptext.py
+++ b/src/git_cai_cli/cli/helptext.py
@@ -30,7 +30,9 @@ Flags:
   -l, --list               List information (e.g. languages, styles, providers, config)
   -m, --model NAME         Override model for this invocation (requires --provider)
   -P, --provider NAME      Override LLM provider for this invocation
-  -p, --generate-prompts   Generate default commit_prompt.md and squash_prompt.md
+  -p, --generate-prompts   Generate default commit/squash/full_files/pr prompt files
+  -r, --PR                 Generate a Pull Request description from the commits on this branch
+      --base BRANCH        Base branch for --PR (overrides auto-detection)
   -S, --set KEY=VALUE      Set a config value in repo config (requires existing repo config)
   -s, --squash [N|HASH]    Squash commits on this branch and summarize them
                            No argument: squash all commits since branch checkout

--- a/src/git_cai_cli/cli/modes.py
+++ b/src/git_cai_cli/cli/modes.py
@@ -15,18 +15,27 @@ class Mode(Enum):
     AMEND = auto()
     COMMIT = auto()
     LIST = auto()
+    PR = auto()
     SQUASH = auto()
     UPDATE = auto()
 
 
-def resolve_mode(*, amend: bool, list_flag: bool, squash: bool, update: bool) -> Mode:
+def resolve_mode(
+    *,
+    amend: bool,
+    list_flag: bool,
+    pr: bool,
+    squash: bool,
+    update: bool,
+) -> Mode:
     """
     Resolves the operational mode based on the provided flags.
     """
-    flags = [amend, list_flag, squash, update]
+    flags = [amend, list_flag, pr, squash, update]
     if sum(flags) > 1:
         typer.echo(
-            "Error: --amend, --list, --squash, and --update cannot be used together.",
+            "Error: --amend, --list, --PR, --squash, and --update "
+            "cannot be used together.",
             err=True,
         )
         raise typer.Exit(code=1)
@@ -35,6 +44,8 @@ def resolve_mode(*, amend: bool, list_flag: bool, squash: bool, update: bool) ->
         return Mode.AMEND
     if list_flag:
         return Mode.LIST
+    if pr:
+        return Mode.PR
     if squash:
         return Mode.SQUASH
     if update:
@@ -68,7 +79,7 @@ def validate_options(
 
     if stage_tracked and mode not in (Mode.COMMIT, Mode.AMEND):
         typer.echo(
-            "Error: --all cannot be used with --list, --update, or --squash.",
+            "Error: --all cannot be used with --list, --update, --PR, or --squash.",
             err=True,
         )
         raise typer.Exit(code=1)
@@ -87,7 +98,7 @@ def validate_options(
         )
         raise typer.Exit(code=1)
 
-    if context and mode not in (Mode.COMMIT, Mode.AMEND, Mode.SQUASH):
+    if context and mode not in (Mode.COMMIT, Mode.AMEND, Mode.SQUASH, Mode.PR):
         typer.echo(
             "Error: --context cannot be used with --list or --update.",
             err=True,
@@ -96,7 +107,7 @@ def validate_options(
 
     if files and mode not in (Mode.COMMIT, Mode.AMEND):
         typer.echo(
-            "Error: --files cannot be used with --list, --update, or --squash.",
+            "Error: --files cannot be used with --list, --update, --PR, or --squash.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/git_cai_cli/core/config.py
+++ b/src/git_cai_cli/core/config.py
@@ -60,6 +60,9 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "measure_time": False,
     "timeout": 30,
     "full_files": False,
+    "pr_to_file": False,
+    "pr_file_name": "PR_DESCRIPTION.md",
+    "pr_prompt_file": "",
 }
 
 # Providers that do not require an API token in tokens.yml
@@ -146,14 +149,19 @@ def load_config(
             if isinstance(value, str) and value.strip().lower() in none_like:
                 config_dict[key] = "none"
 
-        for key in ("prompt_file", "squash_prompt_file", "full_files_prompt_file"):
+        for key in (
+            "prompt_file",
+            "squash_prompt_file",
+            "full_files_prompt_file",
+            "pr_prompt_file",
+        ):
             if key not in config_dict:
                 continue
             value = config_dict.get(key)
             if value is None:
                 config_dict[key] = ""
 
-    def _ensure_prompt_files(prompt_dir: Path) -> tuple[Path, Path, Path]:
+    def _ensure_prompt_files(prompt_dir: Path) -> tuple[Path, Path, Path, Path]:
         """Ensure default prompt files exist in prompt_dir.
 
         Prompt bodies come from the hardcoded fallback strings in
@@ -162,6 +170,7 @@ def load_config(
         from git_cai_cli.core.prompts_fallback import (
             HARDCODED_COMMIT_PROMPT,
             HARDCODED_FULL_FILES_PROMPT,
+            HARDCODED_PR_PROMPT,
             HARDCODED_SQUASH_PROMPT,
         )
 
@@ -170,11 +179,13 @@ def load_config(
         commit_path = prompt_dir / "commit_prompt.md"
         squash_path = prompt_dir / "squash_prompt.md"
         full_files_path = prompt_dir / "full_files_prompt.md"
+        pr_path = prompt_dir / "pr_prompt.md"
 
         targets = (
             (commit_path, HARDCODED_COMMIT_PROMPT, "commit"),
             (squash_path, HARDCODED_SQUASH_PROMPT, "squash"),
             (full_files_path, HARDCODED_FULL_FILES_PROMPT, "full-files"),
+            (pr_path, HARDCODED_PR_PROMPT, "pr"),
         )
 
         for path, body, label in targets:
@@ -182,11 +193,16 @@ def load_config(
                 path.write_text(body, encoding="utf-8")
                 log.info("Default %s prompt written to %s", label, path)
 
-        return commit_path, squash_path, full_files_path
+        return commit_path, squash_path, full_files_path, pr_path
 
     def _normalize_prompt_paths(config_dict: dict[str, Any], base_dir: Path) -> None:
         """Normalize prompt file paths (expand ~/$VARS and resolve relative paths)."""
-        for key in ("prompt_file", "squash_prompt_file", "full_files_prompt_file"):
+        for key in (
+            "prompt_file",
+            "squash_prompt_file",
+            "full_files_prompt_file",
+            "pr_prompt_file",
+        ):
             raw = config_dict.get(key)
             if not isinstance(raw, str):
                 continue
@@ -248,10 +264,12 @@ def load_config(
             commit_prompt_path,
             squash_prompt_path,
             full_files_prompt_path,
+            pr_prompt_path,
         ) = _ensure_prompt_files(fallback_config_file.parent)
         default_config["prompt_file"] = commit_prompt_path
         default_config["squash_prompt_file"] = squash_prompt_path
         default_config["full_files_prompt_file"] = full_files_prompt_path
+        default_config["pr_prompt_file"] = pr_prompt_path
 
         ordered = ordered_default_config(default_config)
 
@@ -398,6 +416,9 @@ def ordered_default_config(
         "measure_time",
         "timeout",
         "full_files",
+        "pr_to_file",
+        "pr_file_name",
+        "pr_prompt_file",
     ]
 
     ordered: dict[str, Any] = {}

--- a/src/git_cai_cli/core/gitutils.py
+++ b/src/git_cai_cli/core/gitutils.py
@@ -225,6 +225,49 @@ def get_current_branch(
         return None
 
 
+def detect_base_branch(
+    run_cmd: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> str:
+    """Resolve the repository's base branch.
+
+    Order of attempts:
+    1. `origin/HEAD` (the remote's default branch).
+    2. local `main`.
+    3. local `master`.
+
+    Raises ValueError if none of these are present.
+    """
+    try:
+        result = run_cmd(
+            ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        ref = result.stdout.strip()
+        if ref.startswith("origin/"):
+            return ref[len("origin/") :]  # type: ignore[misc]  # mypy E203
+        if ref:
+            return ref
+    except subprocess.CalledProcessError:
+        log.debug("origin/HEAD not set; trying local fallbacks.")
+
+    for candidate in ("main", "master"):
+        rc = run_cmd(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{candidate}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).returncode
+        if rc == 0:
+            log.debug("Using local '%s' as base branch.", candidate)
+            return candidate
+
+    raise ValueError(
+        "Could not determine base branch. Set origin/HEAD or pass --base <branch>."
+    )
+
+
 def _has_upstream() -> bool:
     try:
         subprocess.check_output(

--- a/src/git_cai_cli/core/llm.py
+++ b/src/git_cai_cli/core/llm.py
@@ -19,6 +19,7 @@ from git_cai_cli.core.languages import LANGUAGE_MAP
 from git_cai_cli.core.prompts_fallback import (
     HARDCODED_COMMIT_PROMPT,
     HARDCODED_FULL_FILES_PROMPT,
+    HARDCODED_PR_PROMPT,
     HARDCODED_SQUASH_PROMPT,
 )
 from openai import OpenAI
@@ -186,6 +187,36 @@ class CommitMessageGenerator:
 
         return self._dispatch_generate(content=content, system_prompt=prompt)
 
+    def generate_pr_description(
+        self,
+        commit_log: str,
+        changed_files: str,
+        context: str | None = None,
+    ) -> str:
+        """
+        Generate a Markdown Pull Request description from the commit log and
+        changed-files list of a feature branch.
+        """
+        prompt = self._build_pr_prompt()
+        log.debug("PR system prompt preview: %r", prompt[:400])
+
+        sections = [
+            "--- Commit log ---",
+            commit_log.strip() or "(no commits)",
+            "",
+            "--- Changed files ---",
+            changed_files.strip() or "(no files)",
+        ]
+        content = "\n".join(sections)
+
+        if context:
+            content = (
+                f"{content}\n\n"
+                f"--- Additional context from the author ---\n{context}"
+            )
+
+        return self._dispatch_generate(content=content, system_prompt=prompt)
+
     def _emoji_instruction(self) -> str:
         """
         Returns an emoji instruction string, or empty string if emoji is set to "none".
@@ -263,7 +294,9 @@ class CommitMessageGenerator:
             "The scope is optional and describes the section of the codebase affected. "
             "Use a '!' after the type/scope for breaking changes (e.g., 'feat!: ...' or 'feat(api)!: ...'). "
             "The description must be a concise summary in imperative mood, lowercase, no trailing period. "
-            "Additional details follow as bullet points in the body after a blank line."
+            "Additional details follow as bullet points in the body after a blank line. "
+            "If every changed file in the diff is a documentation file "
+            "(a `*.md` file or a file under `docs/`), the type MUST be `docs`."
         )
 
     def _branch_instruction(self) -> str:
@@ -354,6 +387,34 @@ class CommitMessageGenerator:
             prompt = base
 
         log.debug("Final squash prompt (%d characters).", len(prompt))
+        return prompt
+
+    def _build_pr_prompt(self) -> str:
+        """
+        Build the PR description prompt by loading the base prompt from file
+        (with fallback) and appending universal style instructions.
+
+        Only language/style/emoji are appended. `conventional` and
+        `branch_context` are commit-message specific (no `feat(scope):`
+        headline; branch intent is irrelevant to summarizing commits) and
+        are deliberately excluded.
+        """
+        base = load_prompt_file(
+            config_key="pr_prompt_file",
+            config=self.config,
+            default_filename="pr_prompt.md",
+            hardcoded_fallback=HARDCODED_PR_PROMPT,
+        )
+
+        parts = [
+            self._language_instruction(),
+            self._style_instruction(),
+            self._emoji_instruction(),
+        ]
+        suffix = " ".join(p for p in parts if p)
+        prompt = f"{base} {suffix}" if suffix else base
+
+        log.debug("Final PR prompt (%d characters).", len(prompt))
         return prompt
 
     # Keep old method names as aliases for backward compatibility in tests

--- a/src/git_cai_cli/core/options.py
+++ b/src/git_cai_cli/core/options.py
@@ -189,6 +189,7 @@ class CliManager:
         from git_cai_cli.core.prompts_fallback import (
             HARDCODED_COMMIT_PROMPT,
             HARDCODED_FULL_FILES_PROMPT,
+            HARDCODED_PR_PROMPT,
             HARDCODED_SQUASH_PROMPT,
         )
 
@@ -197,6 +198,7 @@ class CliManager:
             (cwd / "commit_prompt.md", HARDCODED_COMMIT_PROMPT, "commit"),
             (cwd / "squash_prompt.md", HARDCODED_SQUASH_PROMPT, "squash"),
             (cwd / "full_files_prompt.md", HARDCODED_FULL_FILES_PROMPT, "full-files"),
+            (cwd / "pr_prompt.md", HARDCODED_PR_PROMPT, "pr"),
         )
 
         for path, _body, _label in targets:

--- a/src/git_cai_cli/core/pr.py
+++ b/src/git_cai_cli/core/pr.py
@@ -1,0 +1,145 @@
+"""
+Generate a Pull Request description from the commits between the current
+branch and its base branch.
+
+This mode never modifies git state: it only reads commit history and
+either prints the generated Markdown to stdout or writes it to a file in
+the repository root, depending on `pr_to_file` in config.
+"""
+
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import typer
+from git_cai_cli.core.config import (
+    TOKENLESS_PROVIDERS,
+    apply_provider_overrides,
+    load_config,
+    load_token,
+)
+from git_cai_cli.core.gitutils import detect_base_branch, find_git_root
+from git_cai_cli.core.llm import CommitMessageGenerator
+from git_cai_cli.core.spinner import Spinner
+
+log = logging.getLogger(__name__)
+
+
+def _merge_base(base_branch: str) -> str:
+    """Return the merge-base between `base_branch` and HEAD."""
+    return subprocess.check_output(
+        ["git", "merge-base", base_branch, "HEAD"], text=True
+    ).strip()
+
+
+def _commit_log(merge_base: str) -> str:
+    """Return the concatenated commit messages between merge_base and HEAD."""
+    return subprocess.check_output(
+        [
+            "git",
+            "--no-pager",
+            "log",
+            f"{merge_base}..HEAD",
+            "--pretty=format:%B",
+        ],
+        text=True,
+    ).strip()
+
+
+def _changed_files(merge_base: str) -> str:
+    """Return the newline-joined list of files changed between merge_base and HEAD."""
+    return subprocess.check_output(
+        ["git", "diff", "--name-only", f"{merge_base}..HEAD"], text=True
+    ).strip()
+
+
+def run_pr(
+    provider_override: str | None = None,
+    model_override: str | None = None,
+    time_flag: bool = False,
+    base_override: str | None = None,
+    context: str | None = None,
+) -> None:
+    """
+    Generate a PR description for the current branch.
+
+    Args:
+        provider_override: Optional. Provider override for this invocation.
+        model_override: Optional. Model override for this invocation.
+        time_flag: Whether to log generation time.
+        base_override: Optional. Explicit base branch (e.g. "develop").
+        context: Optional. Extra context for the LLM.
+    """
+    repo_root = find_git_root()
+    if not repo_root:
+        log.error("Not inside a Git repository.")
+        raise typer.Exit(code=1)
+
+    config = load_config()
+    apply_provider_overrides(config, provider_override, model_override)
+
+    provider = config["default"]
+    token = load_token(config=config)
+
+    if provider not in TOKENLESS_PROVIDERS and not token:
+        log.error(
+            "Missing %s token in %s/.config/cai/tokens.yml",  # nosemgrep
+            provider,
+            Path.home(),
+        )
+        sys.exit(1)
+
+    try:
+        base_branch = base_override or detect_base_branch()
+    except ValueError as e:
+        log.error("%s", e)
+        raise typer.Exit(code=1)
+
+    log.info("Using base branch: %s", base_branch)
+
+    try:
+        merge_base = _merge_base(base_branch)
+    except subprocess.CalledProcessError as e:
+        log.error(
+            "Failed to compute merge-base between '%s' and HEAD: %s",
+            base_branch,
+            e,
+        )
+        raise typer.Exit(code=1)
+
+    commit_log = _commit_log(merge_base)
+    if not commit_log:
+        log.info("No commits between %s and HEAD — nothing to describe.", base_branch)
+        return
+
+    changed_files = _changed_files(merge_base)
+
+    measure = time_flag or config.get("measure_time", False)
+    start = time.perf_counter() if measure else None
+
+    generator = CommitMessageGenerator(token, config, provider)
+    try:
+        try:
+            with Spinner("Generating PR description"):
+                description = generator.generate_pr_description(
+                    commit_log, changed_files, context=context
+                )
+        except ValueError as e:
+            log.error("%s", e)
+            sys.exit(1)
+    finally:
+        generator.close()
+
+    if start is not None:
+        elapsed = time.perf_counter() - start
+        log.info("PR description generated in %.2fs", elapsed)
+
+    if config.get("pr_to_file", False):
+        filename = config.get("pr_file_name") or "PR_DESCRIPTION.md"
+        out_path = repo_root / filename
+        out_path.write_text(description.strip() + "\n", encoding="utf-8")
+        log.info("PR description written to %s", out_path)
+    else:
+        typer.echo(description)

--- a/src/git_cai_cli/core/prompts_fallback.py
+++ b/src/git_cai_cli/core/prompts_fallback.py
@@ -32,6 +32,13 @@ HARDCODED_COMMIT_PROMPT = (
     "- Keep the total message short — aim for clarity over completeness.\n"
     "- Output only the raw commit message. "
     "No markdown fences, no quotes, no extra commentary.\n"
+    "- If every changed file in the diff is a documentation file "
+    "(a `*.md` file or a file under `docs/`), treat the change as a "
+    "documentation update. Use a documentation verb in the subject "
+    'line ("Document", "Update docs", "Clarify", "Revise") rather '
+    'than generic verbs like "Add" or "Fix", and describe the change '
+    "as documentation in the body. Do not classify documentation-only "
+    "changes as features or bug fixes.\n"
     "- If you detect sensitive information (keys, tokens, passwords), "
     "warn about it at the very top before the subject line."
 )
@@ -77,6 +84,13 @@ HARDCODED_FULL_FILES_PROMPT = (
     "- Keep the total message short — aim for clarity over completeness.\n"
     "- Output only the raw commit message. "
     "No markdown fences, no quotes, no extra commentary.\n"
+    "- If every changed file in the diff is a documentation file "
+    "(a `*.md` file or a file under `docs/`), treat the change as a "
+    "documentation update. Use a documentation verb in the subject "
+    'line ("Document", "Update docs", "Clarify", "Revise") rather '
+    'than generic verbs like "Add" or "Fix", and describe the change '
+    "as documentation in the body. Do not classify documentation-only "
+    "changes as features or bug fixes.\n"
     "- If you detect sensitive information (keys, tokens, passwords) in either "
     "the diff or the full file contents, warn about it at the very top before "
     "the subject line."
@@ -106,6 +120,55 @@ HARDCODED_SQUASH_PROMPT = (
     "- Below the subject, leave one blank line, "
     "then add a concise bullet list describing the key themes of the work.\n"
     "- Focus on why the changes were made, not just what was touched.\n"
+    "- If every changed file across the squashed commits is a documentation "
+    "file (a `*.md` file or a file under `docs/`), treat the squashed change "
+    "as a documentation update. Use a documentation verb in the subject "
+    'line ("Document", "Update docs", "Clarify", "Revise") rather than '
+    'generic verbs like "Add" or "Fix", and describe the change as '
+    "documentation in the body. Do not classify documentation-only "
+    "changes as features or bug fixes.\n"
     "- Output only the raw commit message. "
     "No markdown fences, no quotes, no extra commentary."
+)
+
+HARDCODED_PR_PROMPT = (
+    "You are an expert software engineer assistant.\n"
+    "Your task is to draft a Pull Request description from a list of "
+    "commit messages and a list of changed files between a feature branch "
+    "and its base branch.\n"
+    "\n"
+    "Output a Markdown document with exactly two sections:\n"
+    "\n"
+    "## Summary\n"
+    "- A bullet-point list describing the overall intent of the PR. Use as "
+    "many bullets as the work needs — there is no fixed cap. Cover every "
+    "distinct theme of the PR, but group related changes into a single "
+    "bullet instead of listing every file or every commit separately.\n"
+    "- Each bullet must follow the same best practices as a great commit "
+    "message:\n"
+    "  - Use the imperative mood — the bullet must complete the sentence "
+    '"If applied, this commit will …" (e.g. "Add", "Fix", "Refactor", '
+    'not "Added", "Fixes", "Fixing").\n'
+    "  - Capitalize the first word.\n"
+    "  - Do not end the bullet with a period.\n"
+    "  - Wrap continuation lines at 72 characters per line.\n"
+    "  - Explain what changed and why, not how. Focus on the user-visible "
+    "effect, not a per-commit replay or a restatement of filenames.\n"
+    "\n"
+    "## Test plan\n"
+    "- A Markdown checklist (`- [ ] ...`) of concrete steps a reviewer or "
+    "maintainer can run to verify the change. Prefer commands and observable "
+    "outcomes (e.g. `make test`, smoke tests, manual checks) over vague "
+    'items like "tests pass". Use as many checklist items as the change '
+    "warrants.\n"
+    "\n"
+    "Rules:\n"
+    "- Do not invent commits, files, or behavior that is not implied by the "
+    "input. If something is uncertain, write a checklist item that asks the "
+    "reviewer to verify it rather than asserting it.\n"
+    "- Do not include a title line, headers other than the two above, "
+    "or any preamble. Output only the Markdown body.\n"
+    "- Do not wrap the output in code fences.\n"
+    "- If every changed file is a documentation file (`*.md` or under "
+    "`docs/`), describe the PR as a documentation update."
 )

--- a/src/git_cai_cli/core/spinner.py
+++ b/src/git_cai_cli/core/spinner.py
@@ -5,12 +5,60 @@ Displays an animated progress indicator on stderr while a block of code runs.
 Automatically skipped when stderr is not a TTY (e.g. CI, piped output).
 """
 
+import logging
 import sys
 import threading
 
 # Bouncing bar: a block slides back and forth inside brackets
 _BAR_WIDTH = 20
 _BLOCK = "███"
+
+
+class _LineBreakingStream:
+    """Stream proxy that breaks the current spinner line before logging.
+
+    While the spinner is active, log messages are routed through this
+    proxy. The proxy tracks whether the cursor is currently on a line
+    that the spinner has rendered. When it is, a single `\\n` is
+    inserted before the log write so the log lands on a fresh row below
+    the spinner. When it is not (e.g. the previous write was already a
+    log line ending in `\\n`), nothing is inserted — consecutive log
+    messages stay tightly packed without empty rows between them.
+
+    Spinner frames start with `\\r` and are forwarded unchanged.
+    """
+
+    def __init__(self, base):  # type: ignore[no-untyped-def]
+        self._base = base
+        self._cursor_on_spinner_line = False
+        self._lock = threading.Lock()
+
+    def write(self, data: str) -> int:
+        """Write data to the stream, prefixing with a newline if the cursor is on a spinner line."""
+        if not data:
+            return 0
+        with self._lock:
+            if data.startswith("\r"):
+                # Spinner frame — cursor returns to col 0 and overwrites
+                # the line with bouncing-bar content.
+                self._cursor_on_spinner_line = True
+                return self._base.write(data)
+
+            if data.startswith("\n"):
+                # Already starts with a break; don't double it.
+                self._cursor_on_spinner_line = False
+                return self._base.write(data)
+
+            prefix = "\n" if self._cursor_on_spinner_line else ""
+            self._cursor_on_spinner_line = False
+            return self._base.write(prefix + data)
+
+    def flush(self) -> None:
+        """Flush the stream."""
+        self._base.flush()
+
+    def __getattr__(self, name: str):  # type: ignore[no-untyped-def]
+        return getattr(self._base, name)
 
 
 class Spinner:
@@ -20,17 +68,23 @@ class Spinner:
         self._message = message
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
+        self._proxy: _LineBreakingStream | None = None
+        self._original_streams: dict[logging.StreamHandler, object] = {}
 
     def _spin(self) -> None:
         """Animate a bouncing bar until the stop event is set."""
         pos = 0
         direction = 1
         max_pos = _BAR_WIDTH - len(_BLOCK)
+        # Route spinner output through the shared proxy so its CR-prefixed
+        # frames update the proxy's cursor-state. This is what lets log
+        # lines that fire mid-spinner correctly insert a leading newline.
+        out = self._proxy if self._proxy is not None else sys.stderr
 
         while not self._stop_event.is_set():
             block = " " * pos + _BLOCK + " " * (max_pos - pos)
-            sys.stderr.write(f"\r  [{block}] {self._message}")
-            sys.stderr.flush()
+            out.write(f"\r  [{block}] {self._message}")
+            out.flush()
             pos += direction
             if pos >= max_pos or pos <= 0:
                 direction *= -1
@@ -38,11 +92,32 @@ class Spinner:
 
         # Clear the entire line
         total_len = _BAR_WIDTH + len(self._message) + 6
-        sys.stderr.write("\r" + " " * total_len + "\r")
-        sys.stderr.flush()
+        out.write("\r" + " " * total_len + "\r")
+        out.flush()
+
+    def _wrap_log_streams(self) -> None:
+        """Redirect StreamHandlers writing to stderr through the spinner's
+        proxy so spinner frames and log lines share cursor-state."""
+        if self._proxy is None:
+            return
+        for handler in logging.getLogger().handlers:
+            if (
+                isinstance(handler, logging.StreamHandler)
+                and handler.stream is sys.stderr
+                and not isinstance(handler.stream, _LineBreakingStream)
+            ):
+                self._original_streams[handler] = handler.stream
+                handler.stream = self._proxy
+
+    def _unwrap_log_streams(self) -> None:
+        for handler, original in self._original_streams.items():
+            handler.stream = original
+        self._original_streams.clear()
 
     def __enter__(self) -> "Spinner":
         if sys.stderr.isatty():
+            self._proxy = _LineBreakingStream(sys.stderr)
+            self._wrap_log_streams()
             self._thread = threading.Thread(target=self._spin, daemon=True)
             self._thread.start()
         return self
@@ -51,3 +126,5 @@ class Spinner:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=1)
+        self._unwrap_log_streams()
+        self._proxy = None

--- a/src/git_cai_cli/core/validate.py
+++ b/src/git_cai_cli/core/validate.py
@@ -35,6 +35,9 @@ def _validate_config_keys(config: dict[str, Any], reference: dict[str, Any]) -> 
         "measure_time",
         "timeout",
         "full_files",
+        "pr_to_file",
+        "pr_file_name",
+        "pr_prompt_file",
     }
     allowed_provider_keys = set(reference.keys()) - allowed_global_keys
 

--- a/src/git_cai_cli/main.py
+++ b/src/git_cai_cli/main.py
@@ -67,6 +67,7 @@ def run(
     timeout_override: int | None = None,
     full_files_override: bool = False,
     files_override: list[str] | None = None,
+    base_override: str | None = None,
 ) -> None:
     """
     Main function to run the Git CAI CLI tool.
@@ -111,6 +112,18 @@ def run(
             model_override=model_override,
             time_flag=time_flag,
             squash_arg=list_arg,
+            context=context,
+        )
+        return
+
+    if mode is Mode.PR:
+        from git_cai_cli.core.pr import run_pr
+
+        run_pr(
+            provider_override=provider_override,
+            model_override=model_override,
+            time_flag=time_flag,
+            base_override=base_override,
             context=context,
         )
         return

--- a/tests/integration/test_modes_integration.py
+++ b/tests/integration/test_modes_integration.py
@@ -12,23 +12,63 @@ from git_cai_cli.cli.modes import Mode
     "flags,expected_mode",
     [
         (
-            {"amend": False, "list_flag": False, "squash": False, "update": False},
+            {
+                "amend": False,
+                "list_flag": False,
+                "pr": False,
+                "squash": False,
+                "update": False,
+            },
             Mode.COMMIT,
         ),
         (
-            {"amend": True, "list_flag": False, "squash": False, "update": False},
+            {
+                "amend": True,
+                "list_flag": False,
+                "pr": False,
+                "squash": False,
+                "update": False,
+            },
             Mode.AMEND,
         ),
         (
-            {"amend": False, "list_flag": True, "squash": False, "update": False},
+            {
+                "amend": False,
+                "list_flag": True,
+                "pr": False,
+                "squash": False,
+                "update": False,
+            },
             Mode.LIST,
         ),
         (
-            {"amend": False, "list_flag": False, "squash": True, "update": False},
+            {
+                "amend": False,
+                "list_flag": False,
+                "pr": False,
+                "squash": True,
+                "update": False,
+            },
             Mode.SQUASH,
         ),
         (
-            {"amend": False, "list_flag": False, "squash": False, "update": True},
+            {
+                "amend": False,
+                "list_flag": False,
+                "pr": True,
+                "squash": False,
+                "update": False,
+            },
+            Mode.PR,
+        ),
+        (
+            {
+                "amend": False,
+                "list_flag": False,
+                "pr": False,
+                "squash": False,
+                "update": True,
+            },
             Mode.UPDATE,
         ),
     ],
@@ -46,7 +86,9 @@ def test_resolve_mode_conflict_raises(capsys):
     Test that resolve_mode raises typer.Exit if multiple flags are used together.
     """
     with pytest.raises(typer.Exit) as exc:
-        modes.resolve_mode(amend=False, list_flag=True, squash=True, update=False)
+        modes.resolve_mode(
+            amend=False, list_flag=True, pr=False, squash=True, update=False
+        )
     captured = capsys.readouterr()
     assert (
         "cannot be used together" in captured.out
@@ -64,7 +106,7 @@ def test_resolve_mode_conflict_raises(capsys):
             False,
             False,
             False,
-            "Error: --all cannot be used with --list, --update, or --squash.",
+            "Error: --all cannot be used with --list, --update, --PR, or --squash.",
         ),
         (
             Mode.COMMIT,
@@ -146,7 +188,10 @@ def test_validate_options_files_rejected_outside_commit_amend(bad_mode, capsys):
             files=["x.py"],
         )
     captured = capsys.readouterr()
-    assert "--files cannot be used with --list, --update, or --squash." in captured.err
+    assert (
+        "--files cannot be used with --list, --update, --PR, or --squash."
+        in captured.err
+    )
     assert exc.value.exit_code == 1
 
 

--- a/tests/integration/test_pr_integration.py
+++ b/tests/integration/test_pr_integration.py
@@ -1,0 +1,139 @@
+"""
+Integration tests for git_cai_cli.core.pr.run_pr.
+
+Scope:
+- Real filesystem (a temporary git repo is set up).
+- Real Git operations for branching, commits, and base detection.
+- LLM call is mocked.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from git_cai_cli.core.pr import run_pr
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git"] + args, cwd=cwd, check=True)
+
+
+@pytest.fixture
+def feature_branch_repo(tmp_path, monkeypatch) -> Path:
+    """Initialize a git repo with `main` and a `feature/x` branch with one commit."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+    _git(["init", "-b", "main"], cwd=tmp_path)
+    # Disable signing for the test repo so this works on developer machines
+    # that have commit signing globally enabled.
+    _git(["config", "--local", "commit.gpgsign", "false"], cwd=tmp_path)
+    _git(["config", "--local", "tag.gpgsign", "false"], cwd=tmp_path)
+
+    (tmp_path / "README.md").write_text("# repo\n", encoding="utf-8")
+    _git(["add", "README.md"], cwd=tmp_path)
+    _git(["commit", "-m", "Initial commit"], cwd=tmp_path)
+
+    _git(["checkout", "-b", "feature/x"], cwd=tmp_path)
+    (tmp_path / "src.py").write_text("print('hi')\n", encoding="utf-8")
+    _git(["add", "src.py"], cwd=tmp_path)
+    _git(["commit", "-m", "Add src.py"], cwd=tmp_path)
+
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _config_for(tmp_path: Path, **overrides) -> dict:
+    cfg = {
+        "default": "openai",
+        "openai": {"model": "gpt", "temperature": 0},
+        "language": "en",
+        "style": "professional",
+        "emoji": True,
+        "prompt_file": "",
+        "squash_prompt_file": "",
+        "pr_prompt_file": "",
+        "pr_to_file": False,
+        "pr_file_name": "PR_DESCRIPTION.md",
+        "load_tokens_from": str(tmp_path / "tokens.yml"),
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_pr_writes_to_stdout_by_default(feature_branch_repo, capsys):
+    cfg = _config_for(feature_branch_repo)
+
+    with (
+        patch("git_cai_cli.core.pr.load_config", return_value=cfg),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            return_value="## Summary\n- added src\n\n## Test plan\n- [ ] run",
+        ),
+    ):
+        run_pr(base_override="main")
+
+    captured = capsys.readouterr()
+    assert "## Summary" in captured.out
+    assert "## Test plan" in captured.out
+    assert not (feature_branch_repo / "PR_DESCRIPTION.md").exists()
+
+
+def test_pr_writes_to_file_when_pr_to_file_true(feature_branch_repo):
+    cfg = _config_for(feature_branch_repo, pr_to_file=True)
+
+    with (
+        patch("git_cai_cli.core.pr.load_config", return_value=cfg),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            return_value="## Summary\n- added src",
+        ),
+    ):
+        run_pr(base_override="main")
+
+    out_file = feature_branch_repo / "PR_DESCRIPTION.md"
+    assert out_file.exists()
+    assert "## Summary" in out_file.read_text(encoding="utf-8")
+
+
+def test_pr_respects_custom_pr_file_name(feature_branch_repo):
+    cfg = _config_for(feature_branch_repo, pr_to_file=True, pr_file_name="CUSTOM_PR.md")
+
+    with (
+        patch("git_cai_cli.core.pr.load_config", return_value=cfg),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            return_value="BODY",
+        ),
+    ):
+        run_pr(base_override="main")
+
+    assert (feature_branch_repo / "CUSTOM_PR.md").exists()
+    assert not (feature_branch_repo / "PR_DESCRIPTION.md").exists()
+
+
+def test_pr_no_commits_does_nothing(feature_branch_repo, capsys, caplog):
+    """If HEAD has not diverged from base, run_pr should log and exit cleanly."""
+    cfg = _config_for(feature_branch_repo)
+
+    # Move HEAD to main so there is nothing between main and HEAD.
+    _git(["checkout", "main"], cwd=feature_branch_repo)
+
+    with (
+        patch("git_cai_cli.core.pr.load_config", return_value=cfg),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            side_effect=AssertionError("should not be called"),
+        ),
+    ):
+        with caplog.at_level("INFO"):
+            run_pr(base_override="main")
+
+    assert "nothing to describe" in caplog.text

--- a/tests/unit/test_amend.py
+++ b/tests/unit/test_amend.py
@@ -17,14 +17,18 @@ from git_cai_cli.core.gitutils import commit_direct, get_last_commit_diff
 
 def test_resolve_mode_amend():
     """--amend flag should return AMEND mode."""
-    mode = modes.resolve_mode(amend=True, list_flag=False, squash=False, update=False)
+    mode = modes.resolve_mode(
+        amend=True, list_flag=False, pr=False, squash=False, update=False
+    )
     assert mode == Mode.AMEND
 
 
 def test_resolve_mode_amend_conflicts_with_squash(capsys):
     """--amend and --squash cannot be used together."""
     with pytest.raises(typer.Exit) as exc:
-        modes.resolve_mode(amend=True, list_flag=False, squash=True, update=False)
+        modes.resolve_mode(
+            amend=True, list_flag=False, pr=False, squash=True, update=False
+        )
     captured = capsys.readouterr()
     assert (
         "cannot be used together" in captured.out
@@ -36,7 +40,9 @@ def test_resolve_mode_amend_conflicts_with_squash(capsys):
 def test_resolve_mode_amend_conflicts_with_list(capsys):
     """--amend and --list cannot be used together."""
     with pytest.raises(typer.Exit) as exc:
-        modes.resolve_mode(amend=True, list_flag=True, squash=False, update=False)
+        modes.resolve_mode(
+            amend=True, list_flag=True, pr=False, squash=False, update=False
+        )
     captured = capsys.readouterr()
     assert (
         "cannot be used together" in captured.out

--- a/tests/unit/test_modes.py
+++ b/tests/unit/test_modes.py
@@ -10,32 +10,64 @@ from git_cai_cli.cli.modes import Mode
 
 def test_resolve_mode_commit_by_default():
     """No flags should return COMMIT mode."""
-    mode = modes.resolve_mode(amend=False, list_flag=False, squash=False, update=False)
+    mode = modes.resolve_mode(
+        amend=False, list_flag=False, pr=False, squash=False, update=False
+    )
     assert mode == Mode.COMMIT
 
 
 def test_resolve_mode_list_flag():
     """--list flag should return LIST mode."""
-    mode = modes.resolve_mode(amend=False, list_flag=True, squash=False, update=False)
+    mode = modes.resolve_mode(
+        amend=False, list_flag=True, pr=False, squash=False, update=False
+    )
     assert mode == Mode.LIST
 
 
 def test_resolve_mode_squash_flag():
     """--squash flag should return SQUASH mode."""
-    mode = modes.resolve_mode(amend=False, list_flag=False, squash=True, update=False)
+    mode = modes.resolve_mode(
+        amend=False, list_flag=False, pr=False, squash=True, update=False
+    )
     assert mode == Mode.SQUASH
+
+
+def test_resolve_mode_pr_flag():
+    """--PR flag should return PR mode."""
+    mode = modes.resolve_mode(
+        amend=False, list_flag=False, pr=True, squash=False, update=False
+    )
+    assert mode == Mode.PR
 
 
 def test_resolve_mode_update_flag():
     """--update flag should return UPDATE mode."""
-    mode = modes.resolve_mode(amend=False, list_flag=False, squash=False, update=True)
+    mode = modes.resolve_mode(
+        amend=False, list_flag=False, pr=False, squash=False, update=True
+    )
     assert mode == Mode.UPDATE
 
 
 def test_resolve_mode_multiple_flags(capsys):
-    """Using more than one of --list, --squash, --update raises typer.Exit."""
+    """Using more than one of --list, --PR, --squash, --update raises typer.Exit."""
     with pytest.raises(typer.Exit) as exc:
-        modes.resolve_mode(amend=False, list_flag=True, squash=True, update=False)
+        modes.resolve_mode(
+            amend=False, list_flag=True, pr=False, squash=True, update=False
+        )
+    captured = capsys.readouterr()
+    assert (
+        "cannot be used together" in captured.out
+        or "cannot be used together" in captured.err
+    )
+    assert exc.value.exit_code == 1
+
+
+def test_resolve_mode_pr_with_squash_rejected(capsys):
+    """--PR cannot be used with --squash."""
+    with pytest.raises(typer.Exit) as exc:
+        modes.resolve_mode(
+            amend=False, list_flag=False, pr=True, squash=True, update=False
+        )
     captured = capsys.readouterr()
     assert (
         "cannot be used together" in captured.out
@@ -97,8 +129,8 @@ def test_validate_options_stage_tracked_with_non_commit(capsys):
         )
     captured = capsys.readouterr()
     assert (
-        "cannot be used with --list, --update, or --squash" in captured.out
-        or "cannot be used with --list, --update, or --squash" in captured.err
+        "cannot be used with --list, --update" in captured.out
+        or "cannot be used with --list, --update" in captured.err
     )
     assert exc.value.exit_code == 1
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -393,6 +393,19 @@ def test_generate_prompts_here_creates_files(tmp_path, monkeypatch):
     assert (tmp_path / "commit_prompt.md").is_file()
     assert (tmp_path / "squash_prompt.md").is_file()
     assert (tmp_path / "full_files_prompt.md").is_file()
+    assert (tmp_path / "pr_prompt.md").is_file()
+
+
+def test_generate_prompts_here_pr_prompt_has_summary_section(tmp_path, monkeypatch):
+    """The generated pr_prompt.md must carry the PR-specific structure."""
+    manager = CliManager()
+    monkeypatch.chdir(tmp_path)
+
+    manager.generate_prompts_here()
+
+    body = (tmp_path / "pr_prompt.md").read_text(encoding="utf-8")
+    assert "## Summary" in body
+    assert "## Test plan" in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pr.py
+++ b/tests/unit/test_pr.py
@@ -1,0 +1,310 @@
+"""
+Unit tests for git_cai_cli.core.pr.run_pr and supporting helpers.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from git_cai_cli.core.gitutils import detect_base_branch
+from git_cai_cli.core.llm import CommitMessageGenerator
+from git_cai_cli.core.pr import run_pr
+from git_cai_cli.core.prompts_fallback import HARDCODED_PR_PROMPT
+
+
+@pytest.fixture
+def mock_repo_root(tmp_path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "default": "openai",
+        "openai": {"model": "gpt", "temperature": 0},
+        "language": "en",
+        "style": "professional",
+        "emoji": True,
+        "prompt_file": "",
+        "squash_prompt_file": "",
+        "pr_prompt_file": "",
+        "pr_to_file": False,
+        "pr_file_name": "PR_DESCRIPTION.md",
+    }
+
+
+# ---------------------------------------------------------------------------
+# detect_base_branch
+# ---------------------------------------------------------------------------
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess[str](
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_detect_base_branch_uses_origin_head():
+    def fake_run(cmd, **kwargs):
+        if "symbolic-ref" in cmd:
+            return _completed(0, stdout="origin/develop\n")
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    assert detect_base_branch(run_cmd=fake_run) == "develop"
+
+
+def test_detect_base_branch_falls_back_to_main():
+    def fake_run(cmd, **kwargs):
+        if "symbolic-ref" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        if "show-ref" in cmd and "refs/heads/main" in cmd:
+            return _completed(0)
+        if "show-ref" in cmd and "refs/heads/master" in cmd:
+            return _completed(1)
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    assert detect_base_branch(run_cmd=fake_run) == "main"
+
+
+def test_detect_base_branch_falls_back_to_master():
+    def fake_run(cmd, **kwargs):
+        if "symbolic-ref" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        if "show-ref" in cmd and "refs/heads/main" in cmd:
+            return _completed(1)
+        if "show-ref" in cmd and "refs/heads/master" in cmd:
+            return _completed(0)
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    assert detect_base_branch(run_cmd=fake_run) == "master"
+
+
+def test_detect_base_branch_raises_when_nothing_found():
+    def fake_run(cmd, **kwargs):
+        if "symbolic-ref" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        if "show-ref" in cmd:
+            return _completed(1)
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    with pytest.raises(ValueError) as exc:
+        detect_base_branch(run_cmd=fake_run)
+    assert "Could not determine base branch" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# generate_pr_description / _build_pr_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_pr_prompt_falls_back_to_hardcoded(base_config):
+    gen = CommitMessageGenerator(
+        token="fake", config=base_config, default_model="openai"
+    )
+    with patch(
+        "git_cai_cli.core.llm.load_prompt_file", return_value=HARDCODED_PR_PROMPT
+    ):
+        prompt = gen._build_pr_prompt()
+    assert "## Summary" in prompt
+    assert "## Test plan" in prompt
+
+
+def test_build_pr_prompt_appends_language_style_emoji(base_config):
+    """language/style/emoji should be appended to PR prompt the same way
+    they are appended to commit, full-files, and squash prompts."""
+    base_config["language"] = "de"
+    base_config["style"] = "funny"
+    base_config["emoji"] = True
+    gen = CommitMessageGenerator(
+        token="fake", config=base_config, default_model="openai"
+    )
+    with patch(
+        "git_cai_cli.core.llm.load_prompt_file", return_value=HARDCODED_PR_PROMPT
+    ):
+        prompt = gen._build_pr_prompt()
+    assert "German" in prompt
+    assert "funny" in prompt
+    assert "emoji" in prompt.lower()
+
+
+def test_build_pr_prompt_excludes_commit_specific_instructions(base_config):
+    """conventional + branch_context are commit-message specific and must
+    NOT be appended to the PR prompt."""
+    base_config["conventional"] = True
+    base_config["branch_context"] = True
+    base_config["branch_name"] = "feature/x"
+    gen = CommitMessageGenerator(
+        token="fake", config=base_config, default_model="openai"
+    )
+    with patch(
+        "git_cai_cli.core.llm.load_prompt_file", return_value=HARDCODED_PR_PROMPT
+    ):
+        prompt = gen._build_pr_prompt()
+    assert "Conventional Commits specification" not in prompt
+    assert "feature/x" not in prompt
+
+
+def test_generate_pr_description_includes_log_and_files(base_config):
+    gen = CommitMessageGenerator(
+        token="fake", config=base_config, default_model="openai"
+    )
+    with patch.object(gen, "_dispatch_generate", return_value="DRAFT") as disp:
+        result = gen.generate_pr_description(
+            commit_log="msg1\nmsg2", changed_files="a.py\nb.py"
+        )
+
+    assert result == "DRAFT"
+    sent_content = disp.call_args.kwargs["content"]
+    assert "msg1" in sent_content
+    assert "a.py" in sent_content
+    assert "Commit log" in sent_content
+    assert "Changed files" in sent_content
+
+
+def test_generate_pr_description_appends_context(base_config):
+    gen = CommitMessageGenerator(
+        token="fake", config=base_config, default_model="openai"
+    )
+    with patch.object(gen, "_dispatch_generate", return_value="DRAFT") as disp:
+        gen.generate_pr_description(
+            commit_log="msg", changed_files="a.py", context="Closes #42"
+        )
+
+    sent_content = disp.call_args.kwargs["content"]
+    assert "Closes #42" in sent_content
+
+
+# ---------------------------------------------------------------------------
+# run_pr
+# ---------------------------------------------------------------------------
+
+
+def test_run_pr_aborts_outside_git_repo(caplog):
+    with patch("git_cai_cli.core.pr.find_git_root", return_value=None):
+        with pytest.raises(typer.Exit) as exc:
+            run_pr()
+    assert exc.value.exit_code == 1
+    assert "Not inside a Git repository" in caplog.text
+
+
+def test_run_pr_writes_to_stdout_by_default(mock_repo_root, base_config, capsys):
+    """When pr_to_file is False, the PR description is printed to stdout."""
+
+    def fake_check_output(cmd, text=True, **kwargs):
+        if cmd[:2] == ["git", "merge-base"]:
+            return "BASE"
+        if cmd[:3] == ["git", "--no-pager", "log"]:
+            return "feat: add thing\n\nbody\n"
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return "src/foo.py\n"
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    gen = MagicMock()
+    gen.generate_pr_description.return_value = (
+        "## Summary\n- did stuff\n\n## Test plan\n- [ ] check"
+    )
+
+    with (
+        patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
+        patch("git_cai_cli.core.pr.load_config", return_value=base_config),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch("git_cai_cli.core.pr.detect_base_branch", return_value="main"),
+        patch("subprocess.check_output", side_effect=fake_check_output),
+        patch("git_cai_cli.core.pr.CommitMessageGenerator", return_value=gen),
+    ):
+        run_pr()
+
+    captured = capsys.readouterr()
+    assert "## Summary" in captured.out
+    assert "## Test plan" in captured.out
+    # No file was written
+    assert not (mock_repo_root / "PR_DESCRIPTION.md").exists()
+
+
+def test_run_pr_writes_to_file_when_configured(mock_repo_root, base_config):
+    base_config["pr_to_file"] = True
+    base_config["pr_file_name"] = "MY_PR.md"
+
+    def fake_check_output(cmd, text=True, **kwargs):
+        if cmd[:2] == ["git", "merge-base"]:
+            return "BASE"
+        if cmd[:3] == ["git", "--no-pager", "log"]:
+            return "feat: add thing"
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return "src/foo.py"
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    gen = MagicMock()
+    gen.generate_pr_description.return_value = "## Summary\n- ok"
+
+    with (
+        patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
+        patch("git_cai_cli.core.pr.load_config", return_value=base_config),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch("git_cai_cli.core.pr.detect_base_branch", return_value="main"),
+        patch("subprocess.check_output", side_effect=fake_check_output),
+        patch("git_cai_cli.core.pr.CommitMessageGenerator", return_value=gen),
+    ):
+        run_pr()
+
+    written = (mock_repo_root / "MY_PR.md").read_text(encoding="utf-8")
+    assert "## Summary" in written
+
+
+def test_run_pr_uses_explicit_base_override(mock_repo_root, base_config, capsys):
+    """When base_override is passed, detect_base_branch must not be called."""
+    seen_merge_base_args: list[str] = []
+
+    def fake_check_output(cmd, text=True, **kwargs):
+        if cmd[:2] == ["git", "merge-base"]:
+            seen_merge_base_args.extend(cmd[2:])
+            return "BASE"
+        if cmd[:3] == ["git", "--no-pager", "log"]:
+            return "msg"
+        if cmd[:3] == ["git", "diff", "--name-only"]:
+            return "f.py"
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    gen = MagicMock()
+    gen.generate_pr_description.return_value = "BODY"
+
+    with (
+        patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
+        patch("git_cai_cli.core.pr.load_config", return_value=base_config),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.pr.detect_base_branch",
+            side_effect=AssertionError("should not auto-detect"),
+        ),
+        patch("subprocess.check_output", side_effect=fake_check_output),
+        patch("git_cai_cli.core.pr.CommitMessageGenerator", return_value=gen),
+    ):
+        run_pr(base_override="develop")
+
+    assert "develop" in seen_merge_base_args
+
+
+def test_run_pr_skips_when_no_commits(mock_repo_root, base_config, caplog):
+    def fake_check_output(cmd, text=True, **kwargs):
+        if cmd[:2] == ["git", "merge-base"]:
+            return "BASE"
+        if cmd[:3] == ["git", "--no-pager", "log"]:
+            return ""  # no commits
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    with (
+        patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
+        patch("git_cai_cli.core.pr.load_config", return_value=base_config),
+        patch("git_cai_cli.core.pr.load_token", return_value="token"),
+        patch("git_cai_cli.core.pr.detect_base_branch", return_value="main"),
+        patch("subprocess.check_output", side_effect=fake_check_output),
+    ):
+        with caplog.at_level("INFO"):
+            run_pr()
+
+    assert "nothing to describe" in caplog.text

--- a/tests/unit/test_prompt_loading.py
+++ b/tests/unit/test_prompt_loading.py
@@ -12,6 +12,7 @@ from git_cai_cli.core.llm import (
 from git_cai_cli.core.prompts_fallback import (
     HARDCODED_COMMIT_PROMPT,
     HARDCODED_FULL_FILES_PROMPT,
+    HARDCODED_PR_PROMPT,
     HARDCODED_SQUASH_PROMPT,
 )
 
@@ -784,3 +785,135 @@ class TestCbeaComplianceSquashPrompt:
         assert (
             not missing
         ), f"HARDCODED_SQUASH_PROMPT is missing cbea.ms markers: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Documentation-only classification rule
+# ---------------------------------------------------------------------------
+
+
+class TestDocsOnlyRuleInHardcodedPrompts:
+    """All three commit-style hardcoded prompts must guide the LLM to treat
+    documentation-only diffs as documentation, not as features or fixes."""
+
+    def test_hardcoded_commit_prompt_mentions_docs_only_rule(self):
+        assert "*.md" in HARDCODED_COMMIT_PROMPT
+        assert "docs/" in HARDCODED_COMMIT_PROMPT
+        assert "documentation" in HARDCODED_COMMIT_PROMPT.lower()
+
+    def test_hardcoded_full_files_prompt_mentions_docs_only_rule(self):
+        assert "*.md" in HARDCODED_FULL_FILES_PROMPT
+        assert "docs/" in HARDCODED_FULL_FILES_PROMPT
+        assert "documentation" in HARDCODED_FULL_FILES_PROMPT.lower()
+
+    def test_hardcoded_squash_prompt_mentions_docs_only_rule(self):
+        assert "*.md" in HARDCODED_SQUASH_PROMPT
+        assert "docs/" in HARDCODED_SQUASH_PROMPT
+        assert "documentation" in HARDCODED_SQUASH_PROMPT.lower()
+
+
+class TestHardcodedPrPrompt:
+    """The PR prompt must allow any bullet count and follow the same
+    commit-message best practices as the commit prompts."""
+
+    def test_pr_prompt_has_summary_and_test_plan(self):
+        assert "## Summary" in HARDCODED_PR_PROMPT
+        assert "## Test plan" in HARDCODED_PR_PROMPT
+
+    def test_pr_prompt_does_not_cap_bullets(self):
+        # The earlier "1 to 3 bullet points" cap was removed — the LLM
+        # should be free to use as many bullets as the work needs.
+        assert "1 to 3" not in HARDCODED_PR_PROMPT
+        assert "no fixed cap" in HARDCODED_PR_PROMPT
+
+    def test_pr_prompt_requires_commit_message_best_practices(self):
+        # Same bullet conventions as the commit prompts: imperative mood,
+        # capitalization, no trailing period, 72-char wrap, what+why.
+        assert "imperative mood" in HARDCODED_PR_PROMPT
+        assert "If applied" in HARDCODED_PR_PROMPT
+        assert "Capitalize" in HARDCODED_PR_PROMPT
+        assert "Do not end the bullet with a period" in HARDCODED_PR_PROMPT
+        assert "72 characters" in HARDCODED_PR_PROMPT
+        assert "what changed and why" in HARDCODED_PR_PROMPT
+
+    def test_pr_prompt_keeps_docs_only_rule(self):
+        assert "*.md" in HARDCODED_PR_PROMPT
+        assert "docs/" in HARDCODED_PR_PROMPT
+
+
+class TestConventionalInstructionDocsRule:
+    """When conventional commits is enabled, the instruction must require
+    `docs` type for documentation-only diffs."""
+
+    def test_conventional_instruction_requires_docs_type_for_doc_only_changes(
+        self, base_config
+    ):
+        config = dict(base_config)
+        config["conventional"] = True
+        gen = CommitMessageGenerator(
+            token="fake-token", config=config, default_model="openai"
+        )
+        instr = gen._conventional_instruction()
+        assert "docs" in instr
+        assert "MUST" in instr
+        assert "*.md" in instr
+
+    def test_conventional_instruction_empty_when_disabled(self, base_config):
+        config = dict(base_config)
+        config["conventional"] = False
+        gen = CommitMessageGenerator(
+            token="fake-token", config=config, default_model="openai"
+        )
+        assert gen._conventional_instruction() == ""
+
+
+# ---------------------------------------------------------------------------
+# language / style / emoji must apply to ALL prompt builders
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageStyleEmojiCoverAllPrompts:
+    """language, style, and emoji are universal stylistic preferences and
+    must be honored by every prompt builder: commit, full-files, squash,
+    and PR. Regression guard: each new prompt builder must opt in."""
+
+    def _make_gen(self, base_config, **overrides):
+        config = dict(base_config)
+        config.update(overrides)
+        return CommitMessageGenerator(
+            token="fake-token", config=config, default_model="openai"
+        )
+
+    def test_commit_prompt_honors_language_style_emoji(self, base_config):
+        gen = self._make_gen(base_config, language="de", style="funny", emoji=True)
+        prompt = gen._build_commit_prompt()
+        assert "German" in prompt
+        assert "funny" in prompt
+        assert "emoji" in prompt.lower()
+
+    def test_full_files_prompt_honors_language_style_emoji(self, base_config):
+        gen = self._make_gen(
+            base_config,
+            language="de",
+            style="funny",
+            emoji=True,
+            full_files=True,
+        )
+        prompt = gen._build_commit_prompt()  # full_files=True routes here
+        assert "German" in prompt
+        assert "funny" in prompt
+        assert "emoji" in prompt.lower()
+
+    def test_squash_prompt_honors_language_style_emoji(self, base_config):
+        gen = self._make_gen(base_config, language="de", style="funny", emoji=True)
+        prompt = gen._build_squash_prompt()
+        assert "German" in prompt
+        assert "funny" in prompt
+        assert "emoji" in prompt.lower()
+
+    def test_pr_prompt_honors_language_style_emoji(self, base_config):
+        gen = self._make_gen(base_config, language="de", style="funny", emoji=True)
+        prompt = gen._build_pr_prompt()
+        assert "German" in prompt
+        assert "funny" in prompt
+        assert "emoji" in prompt.lower()

--- a/tests/unit/test_spinner.py
+++ b/tests/unit/test_spinner.py
@@ -3,10 +3,11 @@ Unit tests for git_cai_cli.core.spinner module.
 """
 
 import io
+import logging
 import time
 from unittest.mock import patch
 
-from git_cai_cli.core.spinner import Spinner
+from git_cai_cli.core.spinner import Spinner, _LineBreakingStream
 
 
 def test_spinner_starts_and_stops():
@@ -89,3 +90,162 @@ def test_spinner_handles_exception_in_body():
     assert spinner._stop_event.is_set()
     if spinner._thread is not None:
         assert not spinner._thread.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# Log lines must land on a new row, not get smashed against the spinner.
+# ---------------------------------------------------------------------------
+
+
+def test_line_breaking_stream_breaks_only_when_cursor_on_spinner_line():
+    """A `\\n` is inserted only when the previous write was a spinner frame
+    (CR-starting). Consecutive log writes stay tightly packed."""
+    base = io.StringIO()
+    proxy = _LineBreakingStream(base)
+
+    # Initial state: no spinner yet → log lines pass through unchanged.
+    proxy.write("first log line\n")
+    proxy.write("second log line\n")
+
+    # Spinner frame lands → cursor is now on a spinner line.
+    proxy.write("\r  [bar] message")
+
+    # Next log gets a leading `\n` to break off the spinner line.
+    proxy.write("post-spinner log\n")
+
+    # A second log right after stays tight — cursor is already on a fresh line.
+    proxy.write("another log\n")
+
+    out = base.getvalue()
+    assert out == (
+        "first log line\n"
+        "second log line\n"
+        "\r  [bar] message"
+        "\npost-spinner log\n"
+        "another log\n"
+    )
+
+
+def test_line_breaking_stream_passes_through_explicit_newline_writes():
+    """A write that already starts with `\\n` is not double-prefixed."""
+    base = io.StringIO()
+    proxy = _LineBreakingStream(base)
+
+    proxy.write("\r  [bar] message")  # cursor on spinner line
+    proxy.write("\nexplicit break\n")  # already starts with \n; no extra one
+
+    assert base.getvalue() == "\r  [bar] message\nexplicit break\n"
+
+
+def test_line_breaking_stream_skips_empty_writes():
+    base = io.StringIO()
+    proxy = _LineBreakingStream(base)
+
+    proxy.write("")
+
+    assert base.getvalue() == ""
+
+
+def test_log_during_spinner_lands_on_new_line():
+    """When the spinner is active and has rendered a frame, the next log
+    line must be preceded by `\\n` so it lands on a fresh row instead of
+    smashing against the spinner."""
+    mock_stderr = io.StringIO()
+    mock_stderr.isatty = lambda: True  # type: ignore[attr-defined]
+
+    log = logging.getLogger("spinner-newline-test")
+    log.handlers.clear()
+    log.propagate = False
+
+    handler = logging.StreamHandler(mock_stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+
+    with patch("git_cai_cli.core.spinner.sys.stderr", mock_stderr):
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            with Spinner("Generating commit message"):
+                # Wait long enough for the spinner thread to render at
+                # least one frame so the cursor is on a spinner line.
+                time.sleep(0.1)
+                log.info("inner log line")
+        finally:
+            root.removeHandler(handler)
+            log.handlers.clear()
+
+    out = mock_stderr.getvalue()
+    assert "\ninner log line" in out
+
+
+def test_consecutive_logs_during_spinner_have_no_empty_rows():
+    """Two log lines fired back-to-back while the spinner is active must
+    not be separated by an empty row."""
+    mock_stderr = io.StringIO()
+    mock_stderr.isatty = lambda: True  # type: ignore[attr-defined]
+
+    log = logging.getLogger("spinner-consecutive-logs-test")
+    log.handlers.clear()
+    log.propagate = False
+
+    handler = logging.StreamHandler(mock_stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+
+    with patch("git_cai_cli.core.spinner.sys.stderr", mock_stderr):
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            with Spinner("Generating commit message"):
+                time.sleep(0.1)  # let spinner render at least one frame
+                log.info("line one")
+                log.info("line two")
+        finally:
+            root.removeHandler(handler)
+            log.handlers.clear()
+
+    out = mock_stderr.getvalue()
+    # No double-newline between the two consecutive log lines.
+    assert "line one\nline two" in out
+    assert "line one\n\nline two" not in out
+
+
+def test_spinner_restores_handler_streams_on_exit():
+    """After the spinner exits, the root handlers' streams must be restored
+    to their original objects (not the proxy)."""
+    mock_stderr = io.StringIO()
+    mock_stderr.isatty = lambda: True  # type: ignore[attr-defined]
+
+    handler = logging.StreamHandler(mock_stderr)
+    root = logging.getLogger()
+    root.addHandler(handler)
+
+    try:
+        with patch("git_cai_cli.core.spinner.sys.stderr", mock_stderr):
+            with Spinner("X"):
+                assert isinstance(handler.stream, _LineBreakingStream)
+        # After exit, the original stream is back.
+        assert handler.stream is mock_stderr
+    finally:
+        root.removeHandler(handler)
+
+
+def test_spinner_does_not_wrap_when_not_tty():
+    """No tty -> no wrapping (and no spinner thread)."""
+    mock_stderr = io.StringIO()
+    mock_stderr.isatty = lambda: False  # type: ignore[attr-defined]
+
+    handler = logging.StreamHandler(mock_stderr)
+    root = logging.getLogger()
+    root.addHandler(handler)
+
+    try:
+        with patch("git_cai_cli.core.spinner.sys.stderr", mock_stderr):
+            with Spinner("X"):
+                # Stream stays untouched in non-tty mode.
+                assert handler.stream is mock_stderr
+        assert handler.stream is mock_stderr
+    finally:
+        root.removeHandler(handler)


### PR DESCRIPTION
- 📝 Update PR prompt configuration to follow the renamed default template so generated descriptions continue to use the intended review-focused guidance
- ⚙️ Disable writing PR output to a local file by default to better match the current workflow and avoid unnecessary generated artifacts
- 🚀 Establish PR description generation as a supported default path so users can produce review-ready summaries with less manual setup
- 🔧 Improve spinner and logging behavior to preserve clear terminal output across interactive and non-interactive environments
- 🧹 Relax linting and type-checking friction to better fit the current codebase and keep maintenance focused on meaningful issues
- ✅ Expand tests and documentation to protect the PR workflow and make expected CLI behavior easier to understand