### PR TITLE
📊 Simplify stats config and expand tracking

### DIFF
--- a/.linters/.pylintrc
+++ b/.linters/.pylintrc
@@ -66,10 +66,10 @@ check-protected-access-in-special-methods=no
                                            # Don’t warn about protected attr access in dunder methods
 
 [DESIGN]
-max-args=15                                # Max arguments per function
-max-attributes=7                           # Max attributes per class
+max-args=20                                # Max arguments per function
+max-attributes=12                          # Max attributes per class
 max-branches=30                            # Max branches per function
-max-locals=50                              # Max locals per function
+max-locals=60                              # Max locals per function
 max-returns=10                             # Max return statements per function
 max-statements=100                         # Max total statements per function
 max-public-methods=20                      # Max public methods per class
@@ -77,7 +77,7 @@ min-public-methods=1                       # Min public methods per class
 max-nested-blocks=15                       # Max nesting depth
 max-bool-expr=15                           # Max boolean subexpressions in a condition
 max-parents=7                              # Max base classes per class
-max-positional-arguments=15                # Max positional arguments per function
+max-positional-arguments=20                # Max positional arguments per function
 
 [EXCEPTIONS]
 overgeneral-exceptions=builtins.BaseException,builtins.Exception

--- a/cai_config.yml
+++ b/cai_config.yml
@@ -15,6 +15,7 @@ full_files: false
 pr_to_file: false
 pr_file_name: PR_DESCRIPTION.md
 pr_prompt_file: "/home/thorsten/.config/cai/pr_prompt.md"
+stats: true
 anthropic:
   model: claude-haiku-4-5
   temperature: 0

--- a/docs/git-cai.txt
+++ b/docs/git-cai.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 [verse]
 `git cai` [-A | --amend] [-a | --all] [-C | --conventional]
         [-b | --branch] [-c | --crazy] [-d | --debug]
-        [-F | --full-files] [-f PATH | --files PATH]
+        [-F | --full-files | --no-full-files] [-f PATH | --files PATH]
         [-g | --generate-config]
         [-H KEY=VALUE | --set-home KEY=VALUE] [-h | --help]
         [-i | --install-completion]
@@ -23,6 +23,8 @@ SYNOPSIS
         [-r | --PR] [--base BRANCH]
         [-S KEY=VALUE | --set KEY=VALUE]
         [-s [N|HASH] | --squash [N|HASH]]
+        [-Q | --stats] [--since YYYY-MM-DD] [--json] [--reset-stats]
+        [-q true|false | --sql true|false]
         [-T SECONDS | --timeout SECONDS]
         [-t | --time] [-u | --update] [-v | --version]
         [-x CONTEXT | --context CONTEXT]
@@ -97,11 +99,14 @@ Cannot be combined with `--list`, `--update`, or `--squash`.
 git cai -a
 ----
 
--b, --branch::
+-b, --branch / --no-branch::
 Include the current Git branch name as context when generating the commit
 message. The LLM uses the branch name to better understand the intent and
 scope of the changes (e.g., a branch named `fix/login-timeout` hints at a
 bug fix related to login timeouts).
++
+Use `--no-branch` to explicitly disable branch context for this run when
+the persisted config has it enabled.
 +
 This flag applies for the current invocation only. To enable it permanently,
 set `branch_context: true` in `cai_config.yml` or run:
@@ -113,14 +118,18 @@ git cai -S branch_context=true
 ----
 git cai -b
 git cai -b -c
+git cai --no-branch
 ----
 
--C, --conventional::
+-C, --conventional / --no-conventional::
 Generate the commit message in Conventional Commits format
 (`type(scope): description`). The LLM is instructed to use one of the
 following types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
 `build`, `ci`, `chore`, `revert`. Append `!` after the type or scope to
 signal a breaking change.
++
+Use `--no-conventional` to explicitly disable Conventional Commits for
+this run when the persisted config has it enabled.
 +
 This flag applies for the current invocation only. To enable it permanently,
 set `conventional: true` in `cai_config.yml` or run:
@@ -132,6 +141,7 @@ git cai -S conventional=true
 ----
 git cai -C
 git cai -C -c
+git cai --no-conventional
 ----
 
 -c, --crazy::
@@ -457,6 +467,54 @@ git cai -x "Performance optimisation for the search endpoint"
 git cai -A -x "Reword after code review feedback"
 git cai --squash -x "Resolves JIRA-99"
 git cai -r -x "Closes JIRA-1234"
+----
+
+-Q, --stats::
+Show local-only usage analytics: commits and squashes generated, top
+provider, total token counts, average latency, and per-provider rollups.
+Recording is opt-in via the top-level `stats` config key (a plain
+boolean, default `false`), so this view is empty until you turn writing
+on. No diff content, commit messages, or file paths are stored — only
+metadata.
++
+Combine with `--since YYYY-MM-DD` to scope the view to recent activity, or
+with `--json` to emit machine-readable output. Use `--reset-stats` to
+clear the local SQLite database.
++
+The DB lives at `$XDG_DATA_HOME/git-cai/stats.db` (default
+`~/.local/share/git-cai/stats.db`). Override with the top-level
+`stats_db_path` config key.
++
+At the start of every run, git-cai logs whether stats writing is
+enabled and (when enabled) the path of the SQLite database, so users
+always know where their analytics live.
++
+If the running Python build was compiled without sqlite3, this command
+prints a clear message explaining how to fix it; commit generation
+continues to work normally in that case.
++
+The `stats` (and `stats_db_path`) keys are the one configuration
+exception that does not follow the strict repo-replaces-home rule:
+when the repo `cai_config.yml` does not mention them, the values are
+taken from the home `~/.config/cai/cai_config.yml`. If neither file
+defines `stats`, the hardcoded default is `false`. Use `git cai -g` to
+write a fresh config that includes the setting so it is visible.
++
+----
+git cai --stats
+git cai -Q --since 2026-01-01
+git cai -Q --json
+git cai --reset-stats
+----
+
+-q, --sql VALUE::
+Per-invocation override for `stats.enabled`. VALUE is `true` or `false`
+(also accepts `yes/no`, `on/off`, `1/0`). Wins over the persisted config
+value. Useful for one-off opt-in or opt-out without editing the config.
++
+----
+git cai --sql true       # record this commit even when config has stats off
+git cai -q false         # don't record this commit even when config has stats on
 ----
 
 LIST TYPES

--- a/docs/man/git-cai.1
+++ b/docs/man/git-cai.1
@@ -2,12 +2,12 @@
 .\"     Title: git-cai
 .\"    Author: Thorsten Foltz
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-04-27
+.\"      Date: 2026-05-08
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "GIT\-CAI" "1" "2026-04-27" "\ \&" "\ \&"
+.TH "GIT\-CAI" "1" "2026-05-08" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -34,7 +34,7 @@ git-cai \- AI\-powered commit message generator
 .nf
 \f(CRgit cai\fP [\-A | \-\-amend] [\-a | \-\-all] [\-C | \-\-conventional]
         [\-b | \-\-branch] [\-c | \-\-crazy] [\-d | \-\-debug]
-        [\-F | \-\-full\-files] [\-f PATH | \-\-files PATH]
+        [\-F | \-\-full\-files | \-\-no\-full\-files] [\-f PATH | \-\-files PATH]
         [\-g | \-\-generate\-config]
         [\-H KEY=VALUE | \-\-set\-home KEY=VALUE] [\-h | \-\-help]
         [\-i | \-\-install\-completion]
@@ -45,6 +45,8 @@ git-cai \- AI\-powered commit message generator
         [\-r | \-\-PR] [\-\-base BRANCH]
         [\-S KEY=VALUE | \-\-set KEY=VALUE]
         [\-s [N|HASH] | \-\-squash [N|HASH]]
+        [\-Q | \-\-stats] [\-\-since YYYY\-MM\-DD] [\-\-json] [\-\-reset\-stats]
+        [\-q true|false | \-\-sql true|false]
         [\-T SECONDS | \-\-timeout SECONDS]
         [\-t | \-\-time] [\-u | \-\-update] [\-v | \-\-version]
         [\-x CONTEXT | \-\-context CONTEXT]
@@ -225,12 +227,15 @@ git cai \-a
 .if n .RE
 .RE
 .sp
-\-b, \-\-branch
+\-b, \-\-branch / \-\-no\-branch
 .RS 4
 Include the current Git branch name as context when generating the commit
 message. The LLM uses the branch name to better understand the intent and
 scope of the changes (e.g., a branch named \f(CRfix/login\-timeout\fP hints at a
 bug fix related to login timeouts).
+.sp
+Use \f(CR\-\-no\-branch\fP to explicitly disable branch context for this run when
+the persisted config has it enabled.
 .sp
 This flag applies for the current invocation only. To enable it permanently,
 set \f(CRbranch_context: true\fP in \f(CRcai_config.yml\fP or run:
@@ -248,18 +253,22 @@ git cai \-S branch_context=true
 .fam C
 git cai \-b
 git cai \-b \-c
+git cai \-\-no\-branch
 .fam
 .fi
 .if n .RE
 .RE
 .sp
-\-C, \-\-conventional
+\-C, \-\-conventional / \-\-no\-conventional
 .RS 4
 Generate the commit message in Conventional Commits format
 (\f(CRtype(scope): description\fP). The LLM is instructed to use one of the
 following types: \f(CRfeat\fP, \f(CRfix\fP, \f(CRdocs\fP, \f(CRstyle\fP, \f(CRrefactor\fP, \f(CRperf\fP, \f(CRtest\fP,
 \f(CRbuild\fP, \f(CRci\fP, \f(CRchore\fP, \f(CRrevert\fP. Append \f(CR!\fP after the type or scope to
 signal a breaking change.
+.sp
+Use \f(CR\-\-no\-conventional\fP to explicitly disable Conventional Commits for
+this run when the persisted config has it enabled.
 .sp
 This flag applies for the current invocation only. To enable it permanently,
 set \f(CRconventional: true\fP in \f(CRcai_config.yml\fP or run:
@@ -277,6 +286,7 @@ git cai \-S conventional=true
 .fam C
 git cai \-C
 git cai \-C \-c
+git cai \-\-no\-conventional
 .fam
 .fi
 .if n .RE
@@ -740,6 +750,66 @@ git cai \-x "Performance optimisation for the search endpoint"
 git cai \-A \-x "Reword after code review feedback"
 git cai \-\-squash \-x "Resolves JIRA\-99"
 git cai \-r \-x "Closes JIRA\-1234"
+.fam
+.fi
+.if n .RE
+.RE
+.sp
+\-Q, \-\-stats
+.RS 4
+Show local\-only usage analytics: commits and squashes generated, top
+provider, total token counts, average latency, and per\-provider rollups.
+Recording is opt\-in via the top\-level \f(CRstats\fP config key (a plain
+boolean, default \f(CRfalse\fP), so this view is empty until you turn writing
+on. No diff content, commit messages, or file paths are stored — only
+metadata.
+.sp
+Combine with \f(CR\-\-since YYYY\-MM\-DD\fP to scope the view to recent activity, or
+with \f(CR\-\-json\fP to emit machine\-readable output. Use \f(CR\-\-reset\-stats\fP to
+clear the local SQLite database.
+.sp
+The DB lives at \f(CR$XDG_DATA_HOME/git\-cai/stats.db\fP (default
+\f(CR~/.local/share/git\-cai/stats.db\fP). Override with the top\-level
+\f(CRstats_db_path\fP config key.
+.sp
+At the start of every run, git\-cai logs whether stats writing is
+enabled and (when enabled) the path of the SQLite database, so users
+always know where their analytics live.
+.sp
+If the running Python build was compiled without sqlite3, this command
+prints a clear message explaining how to fix it; commit generation
+continues to work normally in that case.
+.sp
+The \f(CRstats\fP (and \f(CRstats_db_path\fP) keys are the one configuration
+exception that does not follow the strict repo\-replaces\-home rule:
+when the repo \f(CRcai_config.yml\fP does not mention them, the values are
+taken from the home \f(CR~/.config/cai/cai_config.yml\fP. If neither file
+defines \f(CRstats\fP, the hardcoded default is \f(CRfalse\fP. Use \f(CRgit cai \-g\fP to
+write a fresh config that includes the setting so it is visible.
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-\-stats
+git cai \-Q \-\-since 2026\-01\-01
+git cai \-Q \-\-json
+git cai \-\-reset\-stats
+.fam
+.fi
+.if n .RE
+.RE
+.sp
+\-q, \-\-sql VALUE
+.RS 4
+Per\-invocation override for \f(CRstats.enabled\fP. VALUE is \f(CRtrue\fP or \f(CRfalse\fP
+(also accepts \f(CRyes/no\fP, \f(CRon/off\fP, \f(CR1/0\fP). Wins over the persisted config
+value. Useful for one\-off opt\-in or opt\-out without editing the config.
+.sp
+.if n .RS 4
+.nf
+.fam C
+git cai \-\-sql true\&       # record this commit even when config has stats off
+git cai \-q false\&         # don\*(Aqt record this commit even when config has stats on
 .fam
 .fi
 .if n .RE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "openai>=2.30.0",
     "typer>=0.23.1",
     "requests>=2.33.0",
+    "pathspec>=0.12.1",
 ]
 license = "MIT"
 classifiers = [

--- a/src/git_cai_cli/cli/cli.py
+++ b/src/git_cai_cli/cli/cli.py
@@ -32,17 +32,17 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
     amend: bool = typer.Option(
         False, "-A", "--amend", help="Regenerate and amend the last commit message"
     ),
-    branch_context: bool = typer.Option(
-        False,
+    branch_context: bool | None = typer.Option(
+        None,
+        "--branch/--no-branch",
         "-b",
-        "--branch",
-        help="Include current branch name as context for the LLM",
+        help="Include current branch name as context for the LLM. Use --no-branch to explicitly disable when the persisted config has it enabled.",
     ),
-    conventional: bool = typer.Option(
-        False,
+    conventional: bool | None = typer.Option(
+        None,
+        "--conventional/--no-conventional",
         "-C",
-        "--conventional",
-        help="Use Conventional Commits format (type(scope): description)",
+        help="Use Conventional Commits format (type(scope): description). Use --no-conventional to explicitly disable when the persisted config has it enabled.",
     ),
     crazy: bool = typer.Option(
         False, "-c", "--crazy", help="Commit immediately without opening editor"
@@ -123,17 +123,44 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
         "--timeout",
         help="HTTP timeout in seconds for this invocation (overrides config; default 30).",
     ),
-    full_files: bool = typer.Option(
-        False,
+    full_files: bool | None = typer.Option(
+        None,
+        "--full-files/--no-full-files",
         "-F",
-        "--full-files",
-        help="Send the full contents of affected files alongside the diff.",
+        help="Send the full contents of affected files alongside the diff. Use --no-full-files to explicitly disable when the persisted config has it enabled.",
     ),
     files: list[str] = typer.Option(
         None,
         "-f",
         "--files",
         help="Limit the diff (and full-file content, if enabled) to these paths. Repeat for multiple files.",
+    ),
+    sql: str = typer.Option(
+        None,
+        "--sql",
+        "-q",
+        help="Override stats writing for this run: --sql true / --sql false. Wins over the persisted `stats` config.",
+    ),
+    stats: bool = typer.Option(
+        False,
+        "--stats",
+        "-Q",
+        help="Show local-only usage analytics (commits per provider, token totals, latency).",
+    ),
+    stats_since: str = typer.Option(
+        None,
+        "--since",
+        help="Filter --stats to events on or after this date (YYYY-MM-DD).",
+    ),
+    stats_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Render --stats output as JSON instead of text.",
+    ),
+    stats_reset: bool = typer.Option(
+        False,
+        "--reset-stats",
+        help="Delete all rows from the local stats DB.",
     ),
 ):
     """
@@ -159,8 +186,20 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
         list_flag=list_flag,
         pr=pr,
         squash=squash,
+        stats=stats,
         update=update,
     )
+
+    sql_override: bool | None = None
+    if sql is not None:
+        normalized = sql.strip().lower()
+        if normalized in ("true", "1", "yes", "on"):
+            sql_override = True
+        elif normalized in ("false", "0", "no", "off"):
+            sql_override = False
+        else:
+            typer.echo(f"Error: --sql expects true/false, got {sql!r}.", err=True)
+            raise typer.Exit(code=1)
 
     validate_options(
         mode=mode,
@@ -246,6 +285,10 @@ def callback(  # pylint: disable=too-many-arguments,too-many-positional-argument
         full_files_override=full_files,
         files_override=files,
         base_override=base,
+        sql_override=sql_override,
+        stats_since=stats_since,
+        stats_json=stats_json,
+        stats_reset=stats_reset,
     )
 
 

--- a/src/git_cai_cli/cli/modes.py
+++ b/src/git_cai_cli/cli/modes.py
@@ -17,6 +17,7 @@ class Mode(Enum):
     LIST = auto()
     PR = auto()
     SQUASH = auto()
+    STATS = auto()
     UPDATE = auto()
 
 
@@ -26,15 +27,16 @@ def resolve_mode(
     list_flag: bool,
     pr: bool,
     squash: bool,
+    stats: bool = False,
     update: bool,
 ) -> Mode:
     """
     Resolves the operational mode based on the provided flags.
     """
-    flags = [amend, list_flag, pr, squash, update]
+    flags = [amend, list_flag, pr, squash, stats, update]
     if sum(flags) > 1:
         typer.echo(
-            "Error: --amend, --list, --PR, --squash, and --update "
+            "Error: --amend, --list, --PR, --squash, --stats, and --update "
             "cannot be used together.",
             err=True,
         )
@@ -48,6 +50,8 @@ def resolve_mode(
         return Mode.PR
     if squash:
         return Mode.SQUASH
+    if stats:
+        return Mode.STATS
     if update:
         return Mode.UPDATE
 

--- a/src/git_cai_cli/core/config.py
+++ b/src/git_cai_cli/core/config.py
@@ -63,6 +63,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "pr_to_file": False,
     "pr_file_name": "PR_DESCRIPTION.md",
     "pr_prompt_file": "",
+    "stats": False,
 }
 
 # Providers that do not require an API token in tokens.yml
@@ -107,6 +108,35 @@ def _find_repo_config() -> Path | None:
 
     log.debug("No repository config found")
     return None
+
+
+def _load_home_stats(home_config_file: Path) -> dict[str, Any] | None:
+    """Read the ``stats``-related keys from the home config (if any).
+
+    Used when a repo config exists but doesn't mention ``stats`` —
+    we fall through to the user's global preference rather than
+    silently disabling analytics. Returns ``None`` if the home
+    config has no relevant keys; otherwise a dict containing
+    whichever of ``stats`` / ``stats_db_path`` are set.
+    """
+    try:
+        if not home_config_file.exists() or home_config_file.stat().st_size == 0:
+            return None
+        with home_config_file.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        log.debug("Could not read home stats fallback: %s", exc)
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    out: dict[str, Any] = {}
+    if "stats" in data:
+        out["stats"] = data["stats"]
+    if "stats_db_path" in data:
+        out["stats_db_path"] = data["stats_db_path"]
+    return out or None
 
 
 def load_config(
@@ -245,6 +275,19 @@ def load_config(
         config["style"] = _validate_style(cast(str | None, config.get("style")))
 
         _normalize_prompt_paths(config, base_dir=repo_config_file.parent)
+
+        # Stats is the only key that falls back through the home config:
+        # users typically configure analytics globally (one DB across
+        # repos), so a repo-level config that omits ``stats`` should not
+        # silently disable it. If the home config also doesn't define
+        # it, the hardcoded default (``stats: false``) wins via
+        # ``stats.is_enabled``'s missing-key handling. Same fallback
+        # applies to the optional ``stats_db_path`` override.
+        if "stats" not in config or "stats_db_path" not in config:
+            home_stats = _load_home_stats(fallback_config_file)
+            if home_stats is not None:
+                for key, value in home_stats.items():
+                    config.setdefault(key, value)
 
         log.info("Repository configuration validated successfully")
         return config
@@ -419,6 +462,8 @@ def ordered_default_config(
         "pr_to_file",
         "pr_file_name",
         "pr_prompt_file",
+        "stats",
+        "stats_db_path",
     ]
 
     ordered: dict[str, Any] = {}
@@ -540,24 +585,32 @@ def set_config_value(key: str, raw_value: str, *, force_home: bool = False) -> P
 def apply_cli_overrides(
     config: dict,
     *,
-    conventional: bool = False,
-    branch_context: bool = False,
+    conventional: bool | None = None,
+    branch_context: bool | None = None,
     timeout_override: int | None = None,
-    full_files_override: bool = False,
+    full_files_override: bool | None = None,
+    sql_override: bool | None = None,
 ) -> None:
     """Apply per-invocation CLI flag overrides to the config dict in-place.
 
-    Only writes keys when the flag was set. Absent flags leave the config
-    value untouched so the persisted default continues to win.
+    Boolean overrides use ``None`` to mean "no override; keep the
+    persisted config value." ``True`` and ``False`` both override —
+    so a user can pass ``--no-conventional`` to flip a persisted
+    ``conventional: true`` off for one invocation.
+
+    ``sql_override`` mirrors ``--sql true|false`` and overrides the
+    top-level ``stats`` boolean.
     """
-    if conventional:
-        config["conventional"] = True
-    if branch_context:
-        config["branch_context"] = True
+    if conventional is not None:
+        config["conventional"] = conventional
+    if branch_context is not None:
+        config["branch_context"] = branch_context
     if timeout_override is not None:
         config["timeout"] = timeout_override
-    if full_files_override:
-        config["full_files"] = True
+    if full_files_override is not None:
+        config["full_files"] = full_files_override
+    if sql_override is not None:
+        config["stats"] = sql_override
 
 
 def apply_provider_overrides(

--- a/src/git_cai_cli/core/gitutils.py
+++ b/src/git_cai_cli/core/gitutils.py
@@ -76,6 +76,14 @@ def find_git_root(
         return None
 
 
+def repo_name_from_root(repo_root: Path | None) -> str | None:
+    """Return the basename of a git root path, or None if unset/empty."""
+    if repo_root is None:
+        return None
+    name = repo_root.name
+    return name or None
+
+
 def _load_caiignore_patterns(repo_root: Path) -> list[str]:
     """Read `.caiignore` from the repo root and return its non-empty patterns."""
     ignore_file = repo_root / ".caiignore"
@@ -120,15 +128,20 @@ def git_diff_excluding(
 
 
 def _matches_caiignore(path: str, patterns: Sequence[str]) -> bool:
-    """Return True if `path` matches any of the `.caiignore` patterns."""
-    import fnmatch
+    """Return True if `path` matches any of the `.caiignore` patterns.
 
-    for pattern in patterns:
-        if fnmatch.fnmatch(path, pattern):
-            return True
-        if "/" not in pattern and fnmatch.fnmatch(os.path.basename(path), pattern):
-            return True
-    return False
+    Uses gitignore semantics via ``pathspec.GitWildMatchPattern`` so
+    users get the behavior they expect: ``**`` recursion, ``!negation``
+    re-inclusion, and directory-anchored patterns (``/foo`` matches at
+    the repo root only; ``foo`` matches anywhere).
+    """
+    if not patterns:
+        return False
+
+    import pathspec
+
+    spec = pathspec.GitIgnoreSpec.from_lines(patterns)
+    return spec.match_file(path)
 
 
 def _is_binary_file(path: Path) -> bool:

--- a/src/git_cai_cli/core/llm.py
+++ b/src/git_cai_cli/core/llm.py
@@ -2,11 +2,13 @@
 Use LLMs to generate git commit messages from diffs or multiple commits.
 """
 
+import functools
 import logging
 import os
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -23,8 +25,62 @@ from git_cai_cli.core.prompts_fallback import (
     HARDCODED_SQUASH_PROMPT,
 )
 from openai import OpenAI
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 log = logging.getLogger(__name__)
+
+
+_RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
+_RETRY_TOTAL = 3
+_RETRY_BACKOFF_FACTOR = 0.5
+
+
+def _build_retrying_session() -> requests.Session:
+    """Build a requests.Session with urllib3-level retry/backoff.
+
+    Retries idempotent and POST requests on 429 + 5xx with exponential
+    backoff. ``raise_for_status`` is still required at the call site so
+    final non-retried failures surface as ``requests.HTTPError`` for the
+    central error classifier in ``validate.py``.
+    """
+    retry = Retry(
+        total=_RETRY_TOTAL,
+        backoff_factor=_RETRY_BACKOFF_FACTOR,
+        status_forcelist=_RETRY_STATUS_CODES,
+        allowed_methods=frozenset({"GET", "POST"}),
+        raise_on_status=False,
+        respect_retry_after_header=True,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    # http:// adapter is required for local Ollama (http://localhost:11434).
+    session.mount(
+        "http://",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
+        adapter,
+    )
+    session.mount("https://", adapter)
+    return session
+
+
+@functools.lru_cache(maxsize=1)
+def _get_http_session() -> requests.Session:
+    """Process-wide retrying session, built lazily on first use.
+
+    ``lru_cache(maxsize=1)`` is used as a thread-safe singleton holder so
+    we avoid the module-level mutable + ``global`` statement pattern.
+    """
+    return _build_retrying_session()
+
+
+def _http_post(*args, **kwargs):
+    """POST via the module-level retrying session.
+
+    Single patch-point for tests; never uses ``requests.post`` directly so
+    every provider call benefits from urllib3 retry/backoff on transient
+    failures (429 / 5xx).
+    """
+    return _get_http_session().post(*args, **kwargs)
 
 
 def load_prompt_file(
@@ -101,10 +157,32 @@ class CommitMessageGenerator:
     Generates git commit messages from diffs or from multiple commit messages.
     """
 
-    def __init__(self, token: str | None, config: Dict[str, Any], default_model: str):
+    def __init__(
+        self,
+        token: str | None,
+        config: Dict[str, Any],
+        default_model: str,
+        *,
+        branch_name: str | None = None,
+    ):
         self.token = token
         self.config = config
         self.default_model = default_model
+        self.branch_name = branch_name
+
+        # Mutated by callers (main / squash / pr) before generation so
+        # the resulting stats row carries the right kind/repo. Default
+        # "commit" because that is the most common entry point.
+        self.kind: str = "commit"
+        self.repo: str | None = None
+
+        # Set by the provider methods around each HTTP call so
+        # ``_log_token_usage`` can persist real latency data.
+        # ``_last_event_id`` is the row id from the most recent
+        # stats.record() — used by ``record_elapsed`` to patch in the
+        # user-perceived elapsed time once the caller knows it.
+        self._last_latency_ms: int | None = None
+        self._last_event_id: int | None = None
 
         # Ollama lifecycle tracking (only used when provider == "ollama")
         self._ollama_proc: subprocess.Popen[str] | None = None
@@ -130,13 +208,91 @@ class CommitMessageGenerator:
 
         return 300 if provider == "ollama" else 30
 
+    _PROMPT_FILE_KEY_BY_KIND: Dict[str, str] = {
+        "commit": "prompt_file",
+        "amend": "prompt_file",
+        "squash": "squash_prompt_file",
+        "pr": "pr_prompt_file",
+    }
+
+    def _settings_snapshot(self, provider: str) -> Dict[str, Any]:
+        """Snapshot of the user-visible generation settings for the
+        active call. Empty/missing values become ``None`` so the stats
+        row reflects "not set" rather than a default lie."""
+        cfg = self.config
+
+        emoji_raw = cfg.get("emoji")
+        emoji_val: bool | None
+        if emoji_raw is None:
+            emoji_val = None
+        else:
+            emoji_val = bool(emoji_raw)
+
+        temperature_val: float | None = None
+        block = cfg.get(provider)
+        if isinstance(block, dict):
+            temp = block.get("temperature")
+            if isinstance(temp, (int, float)):
+                temperature_val = float(temp)
+
+        # Full-files mode swaps the commit prompt file for a dedicated
+        # one — surface that when active, regardless of kind.
+        if self.kind in ("commit", "amend") and cfg.get("full_files"):
+            prompt_key = "full_files_prompt_file"
+        else:
+            prompt_key = self._PROMPT_FILE_KEY_BY_KIND.get(self.kind, "prompt_file")
+        prompt_file_raw = cfg.get(prompt_key)
+        prompt_file_val: str | None = None
+        if isinstance(prompt_file_raw, (str, Path)):
+            text = str(prompt_file_raw).strip()
+            prompt_file_val = text or None
+
+        language_raw = cfg.get("language")
+        language_val = str(language_raw) if language_raw else None
+
+        style_raw = cfg.get("style")
+        style_val = str(style_raw) if style_raw else None
+
+        return {
+            "language": language_val,
+            "style": style_val,
+            "emoji": emoji_val,
+            "temperature": temperature_val,
+            "prompt_file": prompt_file_val,
+        }
+
     def _log_token_usage(
         self,
         provider: str,
         prompt_tokens: int | None,
         completion_tokens: int | None,
     ) -> None:
-        """Log token usage if token_logging is enabled in config."""
+        """Log token usage if token_logging is enabled, and record an
+        analytics event if `stats: true` is set in config (FB.11)."""
+        # Stats recording — best-effort, never raises. Routed before
+        # token_logging short-circuit so analytics still capture even
+        # when token_logging is off.
+        try:
+            from git_cai_cli.core import stats
+
+            model = None
+            block = self.config.get(provider)
+            if isinstance(block, dict):
+                model = block.get("model")
+            self._last_event_id = stats.record(
+                config=self.config,
+                kind=self.kind,
+                provider=provider,
+                model=model,
+                tokens_in=prompt_tokens,
+                tokens_out=completion_tokens,
+                latency_ms=self._last_latency_ms,
+                repo=self.repo,
+                **self._settings_snapshot(provider),
+            )
+        except (ImportError, AttributeError, TypeError, KeyError) as exc:
+            log.debug("stats.record failed (non-fatal): %s", exc)
+
         if not self.config.get("token_logging", False):
             return
         if prompt_tokens is None and completion_tokens is None:
@@ -152,6 +308,17 @@ class CommitMessageGenerator:
             completion_tokens if completion_tokens is not None else "n/a",  # nosemgrep
             total,  # nosemgrep
         )
+
+    def record_elapsed(self, time_ms: int | None) -> None:
+        """Patch the most recent stats event with the user-perceived
+        elapsed time. Best-effort no-op when stats are disabled or no
+        event has been recorded for this generator yet."""
+        try:
+            from git_cai_cli.core import stats
+
+            stats.set_time_ms(self.config, self._last_event_id, time_ms)
+        except (ImportError, AttributeError, TypeError, KeyError) as exc:
+            log.debug("stats.set_time_ms failed (non-fatal): %s", exc)
 
     def generate(self, git_diff: str, context: str | None = None) -> str:
         """
@@ -306,7 +473,7 @@ class CommitMessageGenerator:
         if not self.config.get("branch_context", False):
             return ""
 
-        branch_name = self.config.get("branch_name", "")
+        branch_name = self.branch_name or ""
         if not branch_name:
             return ""
 
@@ -361,7 +528,7 @@ class CommitMessageGenerator:
 
         suffix = self._config_instructions()
         if suffix:
-            prompt = f"{base} {suffix}"
+            prompt = "\n\n".join([base.rstrip(), suffix.lstrip()])
         else:
             prompt = base
 
@@ -382,7 +549,7 @@ class CommitMessageGenerator:
 
         suffix = self._config_instructions()
         if suffix:
-            prompt = f"{base} {suffix}"
+            prompt = "\n\n".join([base.rstrip(), suffix.lstrip()])
         else:
             prompt = base
 
@@ -412,7 +579,7 @@ class CommitMessageGenerator:
             self._emoji_instruction(),
         ]
         suffix = " ".join(p for p in parts if p)
-        prompt = f"{base} {suffix}" if suffix else base
+        prompt = "\n\n".join([base.rstrip(), suffix.lstrip()]) if suffix else base
 
         log.debug("Final PR prompt (%d characters).", len(prompt))
         return prompt
@@ -484,7 +651,14 @@ class CommitMessageGenerator:
 
         model = self.config["anthropic"]["model"]
         temperature = self.config["anthropic"]["temperature"]
-        max_tokens = int(self.config["anthropic"].get("max_tokens", 32768))
+        # ``max_output_tokens`` is the canonical config key (consistent
+        # naming across providers); ``max_tokens`` is kept for backwards
+        # compatibility with existing user configs.
+        anthropic_cfg = self.config["anthropic"]
+        max_tokens = int(
+            anthropic_cfg.get("max_output_tokens")
+            or anthropic_cfg.get("max_tokens", 32768)
+        )
 
         log.info("Using anthropic model '%s'.", model)
 
@@ -501,9 +675,11 @@ class CommitMessageGenerator:
         if system_prompt_override:
             request["system"] = system_prompt_override
 
-        response = requests.post(  # nosec B113
+        start = time.perf_counter()
+        response = _http_post(  # nosec B113
             url, json=request, headers=headers, timeout=self._timeout("anthropic")
         )
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
         response.raise_for_status()
 
         data = response.json()
@@ -570,9 +746,11 @@ class CommitMessageGenerator:
             },
         }
 
-        response = requests.post(  # nosec B113
+        start = time.perf_counter()
+        response = _http_post(  # nosec B113
             url, json=request, headers=headers, timeout=self._timeout("gemini")
         )
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
         response.raise_for_status()
 
         data = response.json()
@@ -630,9 +808,11 @@ class CommitMessageGenerator:
             "temperature": temperature,
         }
 
-        response = requests.post(  # nosec B113
+        start = time.perf_counter()
+        response = _http_post(  # nosec B113
             url, json=request, headers=headers, timeout=self._timeout("groq")
         )
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
         response.raise_for_status()
 
         data = response.json()
@@ -688,9 +868,11 @@ class CommitMessageGenerator:
             "temperature": temperature,
         }
 
-        response = requests.post(  # nosec B113
+        start = time.perf_counter()
+        response = _http_post(  # nosec B113
             url, json=request, headers=headers, timeout=self._timeout("mistral")
         )
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
         response.raise_for_status()
 
         data = response.json()
@@ -703,6 +885,16 @@ class CommitMessageGenerator:
         )
 
         return data["choices"][0]["message"]["content"].strip()
+
+    def _ollama_startup_timeout(self) -> float:
+        """Seconds to wait for ``ollama serve`` to come up. Configurable
+        per-user since first-load of large models can exceed the default."""
+        ollama_cfg = self.config.get("ollama") or {}
+        if isinstance(ollama_cfg, dict):
+            value = ollama_cfg.get("startup_timeout")
+            if isinstance(value, (int, float)) and value > 0:
+                return float(value)
+        return 8.0
 
     def _ollama_base_url(self) -> str:
         host = os.environ.get("OLLAMA_HOST", "").strip()
@@ -740,21 +932,30 @@ class CommitMessageGenerator:
 
         if self._ollama_proc is None or self._ollama_proc.poll() is not None:
             log.info("Ollama is not running; starting 'ollama serve'...")
+            popen_kwargs: Dict[str, Any] = {
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+                "text": True,
+            }
+            # ``start_new_session`` is POSIX-only; using it on Windows
+            # raises ValueError. We need it on POSIX so we can later
+            # killpg() the whole process group, but we have no equivalent
+            # on Windows — fall back to per-process termination there.
+            if sys.platform != "win32":
+                popen_kwargs["start_new_session"] = True
             try:
                 self._ollama_proc = (
                     subprocess.Popen(  # pylint: disable=consider-using-with
                         ["ollama", "serve"],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        text=True,
-                        start_new_session=True,
+                        **popen_kwargs,
                     )
                 )
             except OSError as exc:
                 raise ValueError("Failed to start Ollama server.") from exc
             self._ollama_started_by_us = True
 
-        deadline = time.time() + 8
+        startup_timeout = self._ollama_startup_timeout()
+        deadline = time.time() + startup_timeout
         while time.time() < deadline:
             if self._ollama_proc is not None and self._ollama_proc.poll() is not None:
                 raise ValueError(
@@ -778,8 +979,14 @@ class CommitMessageGenerator:
 
         log.info("Stopping Ollama server started by cai...")
 
+        # POSIX: terminate the process group so child workers exit too.
+        # Windows: no killpg, just terminate the parent process.
+        posix = sys.platform != "win32"
         try:
-            os.killpg(self._ollama_proc.pid, signal.SIGTERM)
+            if posix:
+                os.killpg(self._ollama_proc.pid, signal.SIGTERM)
+            else:
+                self._ollama_proc.terminate()
         except (ProcessLookupError, PermissionError, OSError):
             try:
                 self._ollama_proc.terminate()
@@ -791,7 +998,10 @@ class CommitMessageGenerator:
             log.info("Ollama server stopped successfully.")
         except subprocess.TimeoutExpired:
             try:
-                os.killpg(self._ollama_proc.pid, signal.SIGKILL)
+                if posix:
+                    os.killpg(self._ollama_proc.pid, signal.SIGKILL)
+                else:
+                    self._ollama_proc.kill()
                 log.info("Ollama server killed successfully.")
             except (ProcessLookupError, PermissionError, OSError):
                 try:
@@ -836,14 +1046,16 @@ class CommitMessageGenerator:
             },
         }
 
+        start = time.perf_counter()
         try:
-            response = requests.post(  # nosec B113
+            response = _http_post(  # nosec B113
                 url, json=request, timeout=self._timeout("ollama")
             )
         except requests.RequestException as exc:
             raise ValueError(
                 "Failed to reach Ollama. Ensure it is running (try: `ollama serve`)."
             ) from exc
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
 
         try:
             response.raise_for_status()
@@ -920,12 +1132,14 @@ class CommitMessageGenerator:
 
         messages.append({"role": "user", "content": content})
 
+        start = time.perf_counter()
         completion = client.chat.completions.create(
             model=model,
             messages=messages,
             temperature=temperature,
             stream=False,
         )
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
 
         usage = completion.usage
         self._log_token_usage(
@@ -977,9 +1191,11 @@ class CommitMessageGenerator:
             "messages": messages,
             "temperature": temperature,
         }
-        response = requests.post(  # nosec B113
+        start = time.perf_counter()
+        response = _http_post(  # nosec B113
             url, json=request, headers=headers, timeout=self._timeout("xai")
         )
+        self._last_latency_ms = int((time.perf_counter() - start) * 1000)
         response.raise_for_status()
 
         data = response.json()

--- a/src/git_cai_cli/core/options.py
+++ b/src/git_cai_cli/core/options.py
@@ -367,6 +367,7 @@ git cai -l style
         time_flag: bool = False,
         squash_arg: str | None = None,
         context: str | None = None,
+        sql_override: bool | None = None,
     ) -> None:
         """
         Squash commits on the current branch and summarize them.
@@ -377,6 +378,7 @@ git cai -l style
             time_flag=time_flag,
             squash_arg=squash_arg,
             context=context,
+            sql_override=sql_override,
         )
 
     def stage_tracked_files(self) -> None:

--- a/src/git_cai_cli/core/pr.py
+++ b/src/git_cai_cli/core/pr.py
@@ -20,7 +20,11 @@ from git_cai_cli.core.config import (
     load_config,
     load_token,
 )
-from git_cai_cli.core.gitutils import detect_base_branch, find_git_root
+from git_cai_cli.core.gitutils import (
+    detect_base_branch,
+    find_git_root,
+    repo_name_from_root,
+)
 from git_cai_cli.core.llm import CommitMessageGenerator
 from git_cai_cli.core.spinner import Spinner
 
@@ -61,6 +65,7 @@ def run_pr(
     time_flag: bool = False,
     base_override: str | None = None,
     context: str | None = None,
+    sql_override: bool | None = None,
 ) -> None:
     """
     Generate a PR description for the current branch.
@@ -79,6 +84,12 @@ def run_pr(
 
     config = load_config()
     apply_provider_overrides(config, provider_override, model_override)
+
+    from git_cai_cli.core import stats as stats_module
+    from git_cai_cli.core.config import apply_cli_overrides
+
+    apply_cli_overrides(config, sql_override=sql_override)
+    stats_module.log_state(config)
 
     provider = config["default"]
     token = load_token(config=config)
@@ -120,6 +131,8 @@ def run_pr(
     start = time.perf_counter() if measure else None
 
     generator = CommitMessageGenerator(token, config, provider)
+    generator.kind = "pr"
+    generator.repo = repo_name_from_root(repo_root)
     try:
         try:
             with Spinner("Generating PR description"):
@@ -135,6 +148,7 @@ def run_pr(
     if start is not None:
         elapsed = time.perf_counter() - start
         log.info("PR description generated in %.2fs", elapsed)
+        generator.record_elapsed(int(elapsed * 1000))
 
     if config.get("pr_to_file", False):
         filename = config.get("pr_file_name") or "PR_DESCRIPTION.md"

--- a/src/git_cai_cli/core/squash.py
+++ b/src/git_cai_cli/core/squash.py
@@ -23,6 +23,7 @@ from git_cai_cli.core.gitutils import (
     find_git_root,
     get_git_editor,
     git_diff_excluding,
+    repo_name_from_root,
     sha256_of_file,
 )
 from git_cai_cli.core.llm import CommitMessageGenerator
@@ -80,6 +81,23 @@ def _count_total_commits() -> int:
         ["git", "rev-list", "--count", "HEAD"], text=True
     ).strip()
     return int(output)
+
+
+def _is_shallow_clone() -> bool:
+    """Return True if the current repo is a shallow clone.
+
+    Squash relies on traversing branch history (``HEAD~N``,
+    ``merge-base``); a shallow clone may lack the commits required and
+    git emits cryptic ``unknown revision`` errors. We pre-flight this
+    check so the user gets a clear message.
+    """
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--is-shallow-repository"], text=True
+        ).strip()
+    except subprocess.CalledProcessError:
+        return False
+    return out == "true"
 
 
 def _resolve_squash_target(squash_arg: str) -> str:
@@ -185,6 +203,7 @@ def squash_branch(
     time_flag: bool = False,
     squash_arg: str | None = None,
     context: str | None = None,
+    sql_override: bool | None = None,
 ) -> None:
     """
     Squash commits in the current branch into a single commit with an LLM-generated message.
@@ -200,6 +219,15 @@ def squash_branch(
         log.error("Not inside a Git repository.")
         return
 
+    if _is_shallow_clone():
+        log.error(
+            "This repository is a shallow clone. Squash needs full branch "
+            "history (HEAD~N and merge-base). Run "
+            "`git fetch --unshallow` (or `git fetch --depth=<N>`) to fetch "
+            "the missing commits, then retry."
+        )
+        return
+
     staged = subprocess.check_output(
         ["git", "diff", "--cached", "--name-only"], text=True
     ).strip()
@@ -212,6 +240,17 @@ def squash_branch(
     # Apply provider/model overrides
     apply_provider_overrides(config, provider_override, model_override)
 
+    # `--sql true|false` honored in squash mode too: stats writing
+    # must behave consistently across `git cai`, `git cai -s`, and
+    # `git cai -r`.
+    from git_cai_cli.core.config import apply_cli_overrides
+
+    apply_cli_overrides(config, sql_override=sql_override)
+
+    from git_cai_cli.core import stats as stats_module
+
+    stats_module.log_state(config)
+
     provider = config["default"]
     token = load_token(config=config)
 
@@ -223,6 +262,7 @@ def squash_branch(
         )
         sys.exit(1)
     generator = CommitMessageGenerator(token, config, provider)
+    generator.repo = repo_name_from_root(repo_root)
 
     measure = time_flag or config.get("measure_time", False)
 
@@ -240,6 +280,7 @@ def squash_branch(
 
             start = time.perf_counter() if measure else None
 
+            generator.kind = "commit"
             try:
                 with Spinner("Generating commit message for staged changes"):
                     msg = generator.generate(diff)
@@ -250,12 +291,16 @@ def squash_branch(
             if start is not None:
                 elapsed = time.perf_counter() - start
                 log.info("Commit message generated in %.2fs", elapsed)
+                generator.record_elapsed(int(elapsed * 1000))
 
             result = commit_with_edit_template(msg)
             if result != 0:
-                log.info(
-                    "Commit aborted — squash cancelled. "
-                    "Note: staged changes were already committed."
+                log.warning(
+                    "Commit aborted — squash cancelled.\n"
+                    "Your previously staged changes were already committed before "
+                    "the squash step ran. To roll that commit back into the staging "
+                    "area without losing any work, run:\n\n"
+                    "    git reset HEAD~1 --soft\n"
                 )
                 return
 
@@ -297,6 +342,7 @@ def squash_branch(
 
         start = time.perf_counter() if measure else None
 
+        generator.kind = "squash"
         try:
             with Spinner("Summarizing commit history"):
                 summary_message = generator.summarize_commit_history(
@@ -309,6 +355,7 @@ def squash_branch(
         if start is not None:
             elapsed = time.perf_counter() - start
             log.info("Squash summary generated in %.2fs", elapsed)
+            generator.record_elapsed(int(elapsed * 1000))
 
         # 4) Let user edit the summary without making a commit yet
         log.info(
@@ -326,15 +373,14 @@ def squash_branch(
 
             editor = get_git_editor()
             parts = shlex.split(editor)
-            if not shutil.which(parts[0]):
-                # This editor command requires shell interpretation
-                rc = subprocess.run(
-                    f'{editor} "{tf_name}"',
-                    shell=True,
-                    check=False,  # nosemgrep
-                ).returncode  # nosec # nosemgrep
-            else:
-                rc = subprocess.run(parts + [str(tf_name)], check=False).returncode
+            if not parts or not shutil.which(parts[0]):
+                log.error(
+                    "Editor %r not found in PATH; please set GIT_EDITOR properly.",
+                    editor,
+                )
+                return
+
+            rc = subprocess.run(parts + [str(tf_name)], check=False).returncode
 
             if rc != 0:
                 log.info("Editor exited non-zero — squash cancelled.")

--- a/src/git_cai_cli/core/stats.py
+++ b/src/git_cai_cli/core/stats.py
@@ -1,0 +1,419 @@
+"""Local-only usage analytics for git-cai (FB.11).
+
+Records per-generation events to a SQLite DB under ``XDG_DATA_HOME``
+(default: ``~/.local/share/git-cai/stats.db``). No diff content,
+commit messages, or file paths are stored — only metadata: timestamp,
+provider, model, token counts, latency, success.
+
+Recording is opt-in (``stats: true`` in cai_config.yml, default
+``false``) and best-effort: a failed write must never break commit
+generation. Cost estimation is intentionally not implemented —
+provider prices change too often for any local approximation to stay
+accurate.
+
+The optional ``stats_db_path`` top-level config key overrides the
+default DB location.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import logging
+import os
+from collections import OrderedDict
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+try:
+    import sqlite3
+except ImportError:  # minimal CPython builds may ship without _sqlite3
+    sqlite3 = None  # type: ignore[assignment]
+
+log = logging.getLogger(__name__)
+
+# Exceptions worth swallowing during best-effort stats writes. We compute
+# this once at module load so call sites can reference a real tuple
+# (avoiding broad ``except Exception``). When sqlite is missing we still
+# guard against filesystem failures.
+_STATS_WRITE_FAILURES: tuple[type[BaseException], ...] = (
+    (sqlite3.Error, OSError) if sqlite3 is not None else (OSError,)
+)
+
+
+@functools.lru_cache(maxsize=1)
+def _warn_sqlite_missing_once() -> None:
+    """Log the once-per-process warning that sqlite3 is unavailable."""
+    log.warning(
+        "sqlite3 module is not available in this Python build. "
+        "git-cai stats will be disabled for this run. "
+        "To fix: rebuild Python with sqlite headers, or set "
+        "`stats: false` in cai_config.yml to silence this warning."
+    )
+
+
+def _sqlite_available() -> bool:
+    """Return True if the runtime's stdlib sqlite3 is importable."""
+    if sqlite3 is None:
+        _warn_sqlite_missing_once()
+        return False
+    return True
+
+
+def _default_db_path() -> Path:
+    """Return the default stats DB path under XDG_DATA_HOME."""
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "git-cai" / "stats.db"
+
+
+def resolve_db_path(config: dict[str, Any] | None) -> Path:
+    """Resolve the stats DB path from config, with default fallback."""
+    if config:
+        override = config.get("stats_db_path")
+        if override:
+            return Path(str(override)).expanduser()
+    return _default_db_path()
+
+
+def is_enabled(config: dict[str, Any] | None) -> bool:
+    """Stats writing is opt-in: ``stats: true|false`` at the top level
+    of the config. Defaults to ``False`` when the key is unset.
+
+    A nested ``stats: {enabled: ...}`` shape is rejected (logged
+    once) — only the flat boolean form is supported.
+    """
+    if not config:
+        return False
+    raw = config.get("stats", False)
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, dict):
+        _warn_legacy_stats_shape_once()
+        return False
+    return bool(raw)
+
+
+@functools.lru_cache(maxsize=1)
+def _warn_legacy_stats_shape_once() -> None:
+    """Log the once-per-process deprecation warning for the legacy
+    ``stats: {enabled: ...}`` config shape."""
+    log.warning(
+        "Config key `stats` is a mapping; the supported form is "
+        "now a plain boolean (`stats: true` or `stats: false`). "
+        "Treating this run as disabled."
+    )
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    repo TEXT,
+    provider TEXT NOT NULL,
+    model TEXT,
+    tokens_in INTEGER,
+    tokens_out INTEGER,
+    latency_ms INTEGER,
+    success INTEGER NOT NULL DEFAULT 1,
+    language TEXT,
+    style TEXT,
+    emoji INTEGER,
+    temperature REAL,
+    prompt_file TEXT,
+    time_ms INTEGER
+);
+CREATE INDEX IF NOT EXISTS events_ts ON events(ts);
+CREATE INDEX IF NOT EXISTS events_provider ON events(provider);
+CREATE INDEX IF NOT EXISTS events_kind ON events(kind);
+CREATE INDEX IF NOT EXISTS events_repo ON events(repo);
+"""
+
+
+@contextmanager
+def _connect(db_path: Path) -> Iterator[Any]:
+    # Callers gate on ``_sqlite_available()`` first, so ``sqlite3`` is
+    # guaranteed to be a real module here — but we re-check defensively
+    # rather than ``assert`` (which is stripped under ``python -O``).
+    if sqlite3 is None:
+        raise RuntimeError(
+            "sqlite3 unavailable; caller must gate on _sqlite_available()"
+        )
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(_SCHEMA)
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def record(
+    *,
+    config: dict[str, Any] | None,
+    kind: str,
+    provider: str,
+    model: str | None,
+    tokens_in: int | None,
+    tokens_out: int | None,
+    latency_ms: int | None,
+    success: bool = True,
+    repo: str | None = None,
+    language: str | None = None,
+    style: str | None = None,
+    emoji: bool | None = None,
+    temperature: float | None = None,
+    prompt_file: str | None = None,
+) -> int | None:
+    """Record one analytics event. Best-effort, never raises.
+
+    Returns the inserted row id on success, or ``None`` when stats are
+    disabled, sqlite is unavailable, or the write fails. The id lets a
+    caller patch the row later (e.g. ``set_time_ms`` once the
+    user-perceived elapsed time is known).
+    """
+    if not is_enabled(config):
+        return None
+    if not _sqlite_available():
+        return None
+    try:
+        from datetime import datetime, timezone
+
+        db_path = resolve_db_path(config)
+        ts = datetime.now(timezone.utc).isoformat()
+        emoji_int = None if emoji is None else (1 if emoji else 0)
+        with _connect(db_path) as conn:
+            cur = conn.execute(
+                "INSERT INTO events ("
+                "ts, kind, repo, provider, model, tokens_in, tokens_out, "
+                "latency_ms, success, language, style, emoji, temperature, "
+                "prompt_file"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    ts,
+                    kind,
+                    repo,
+                    provider,
+                    model,
+                    tokens_in,
+                    tokens_out,
+                    latency_ms,
+                    1 if success else 0,
+                    language,
+                    style,
+                    emoji_int,
+                    temperature,
+                    prompt_file,
+                ),
+            )
+            return cur.lastrowid
+    except _STATS_WRITE_FAILURES as exc:
+        log.debug("stats.record failed (non-fatal): %s", exc)
+        return None
+
+
+def set_time_ms(
+    config: dict[str, Any] | None,
+    event_id: int | None,
+    time_ms: int | None,
+) -> None:
+    """Patch an existing event's ``time_ms`` column. Best-effort no-op
+    when stats are disabled, sqlite is unavailable, or inputs are
+    missing — used to record the user-perceived elapsed time once it's
+    known (only when ``-t`` / ``--time`` is set)."""
+    if event_id is None or time_ms is None:
+        return
+    if not is_enabled(config):
+        return
+    if not _sqlite_available():
+        return
+    try:
+        db_path = resolve_db_path(config)
+        if not db_path.exists():
+            return
+        with _connect(db_path) as conn:
+            conn.execute(
+                "UPDATE events SET time_ms = ? WHERE id = ?",
+                (time_ms, event_id),
+            )
+    except _STATS_WRITE_FAILURES as exc:
+        log.debug("stats.set_time_ms failed (non-fatal): %s", exc)
+
+
+def reset(config: dict[str, Any] | None) -> int:
+    """Drop all rows. Returns the number of rows deleted, or 0 on failure."""
+    if not _sqlite_available():
+        return 0
+    try:
+        db_path = resolve_db_path(config)
+        if not db_path.exists():
+            return 0
+        with _connect(db_path) as conn:
+            cur = conn.execute("DELETE FROM events")
+            return cur.rowcount or 0
+    except _STATS_WRITE_FAILURES as exc:
+        log.error("Failed to reset stats DB: %s", exc)
+        return 0
+
+
+def _aggregate(
+    config: dict[str, Any] | None,
+    *,
+    since: str | None = None,
+    provider: str | None = None,
+) -> dict[str, Any]:
+    """Build the summary dict consumed by the renderers."""
+    summary: dict[str, Any] = {
+        "since": since,
+        "provider_filter": provider,
+        "total_commits": 0,
+        "total_amends": 0,
+        "total_squashes": 0,
+        "total_prs": 0,
+        "total_tokens_in": 0,
+        "total_tokens_out": 0,
+        "avg_latency_ms": None,
+        "top_provider": None,
+        "per_provider": [],
+    }
+
+    if not _sqlite_available():
+        return summary
+
+    db_path = resolve_db_path(config)
+    if not db_path.exists():
+        return summary
+
+    where: list[str] = []
+    params: list[Any] = []
+    if since:
+        where.append("ts >= ?")
+        params.append(since)
+    if provider:
+        where.append("provider = ?")
+        params.append(provider)
+    where_clause = f"WHERE {' AND '.join(where)}" if where else ""
+
+    with _connect(db_path) as conn:
+        # Per-provider rollups
+        rows = conn.execute(
+            f"SELECT provider, COUNT(*), "
+            f"COALESCE(SUM(tokens_in), 0), COALESCE(SUM(tokens_out), 0), "
+            f"AVG(latency_ms) "
+            f"FROM events {where_clause} GROUP BY provider ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall()
+
+        per_provider = []
+        for prov, count, tin, tout, avg_lat in rows:
+            per_provider.append(
+                OrderedDict(
+                    [
+                        ("provider", prov),
+                        ("count", count),
+                        ("tokens_in", tin),
+                        ("tokens_out", tout),
+                        ("avg_latency_ms", round(avg_lat) if avg_lat else None),
+                    ]
+                )
+            )
+        summary["per_provider"] = per_provider
+
+        if per_provider:
+            summary["top_provider"] = per_provider[0]["provider"]
+
+        # Totals
+        totals = conn.execute(
+            f"SELECT "
+            f"  SUM(CASE WHEN kind = 'commit' THEN 1 ELSE 0 END), "
+            f"  SUM(CASE WHEN kind = 'amend'  THEN 1 ELSE 0 END), "
+            f"  SUM(CASE WHEN kind = 'squash' THEN 1 ELSE 0 END), "
+            f"  SUM(CASE WHEN kind = 'pr'     THEN 1 ELSE 0 END), "
+            f"  COALESCE(SUM(tokens_in), 0), "
+            f"  COALESCE(SUM(tokens_out), 0), "
+            f"  AVG(latency_ms) "
+            f"FROM events {where_clause}",
+            params,
+        ).fetchone()
+        if totals:
+            commits, amends, squashes, prs, tin, tout, avg_lat = totals
+            summary["total_commits"] = commits or 0
+            summary["total_amends"] = amends or 0
+            summary["total_squashes"] = squashes or 0
+            summary["total_prs"] = prs or 0
+            summary["total_tokens_in"] = tin or 0
+            summary["total_tokens_out"] = tout or 0
+            summary["avg_latency_ms"] = round(avg_lat) if avg_lat else None
+
+    return summary
+
+
+def render_text(summary: dict[str, Any]) -> str:
+    """Render the human-readable text view."""
+    lines = [
+        "git-cai usage"
+        + (f" (since {summary['since']})" if summary.get("since") else "")
+    ]
+    lines.append("─" * 33)
+    lines.append(f"Commits generated:        {summary['total_commits']}")
+    lines.append(f"Amends:                   {summary.get('total_amends', 0)}")
+    lines.append(f"Squashes:                 {summary['total_squashes']}")
+    lines.append(f"PR descriptions:          {summary.get('total_prs', 0)}")
+    if summary.get("top_provider"):
+        lines.append(f"Top provider:             {summary['top_provider']}")
+    lines.append(
+        f"Total tokens:             {summary['total_tokens_in']:,} in / "
+        f"{summary['total_tokens_out']:,} out"
+    )
+    if summary.get("avg_latency_ms") is not None:
+        lines.append(f"Avg latency:              {summary['avg_latency_ms']/1000:.1f}s")
+    lines.append("─" * 33)
+    if summary["per_provider"]:
+        lines.append("Per provider:")
+        for row in summary["per_provider"]:
+            lat = (
+                f"{row['avg_latency_ms']/1000:.1f}s avg"
+                if row.get("avg_latency_ms") is not None
+                else "—"
+            )
+            lines.append(
+                f"  {row['provider']:<10} {row['count']:>4}   "
+                f"{row['tokens_in']:>7,} in / {row['tokens_out']:>5,} out   {lat}"
+            )
+    return "\n".join(lines)
+
+
+def log_state(config: dict[str, Any] | None) -> None:
+    """Log whether stats writing is enabled, and where the DB lives.
+
+    Lives in ``stats`` (rather than ``main``) so ``core.pr`` and
+    ``core.squash`` can call it without re-introducing a cyclic
+    import back into the entry point module.
+    """
+    if is_enabled(config):
+        log.info("Stats writing enabled — recording to %s", resolve_db_path(config))
+    else:
+        log.info("Stats writing disabled")
+
+
+def show(
+    config: dict[str, Any] | None,
+    *,
+    since: str | None = None,
+    provider: str | None = None,
+    as_json: bool = False,
+) -> str:
+    """Build the user-facing stats output as a string."""
+    if not _sqlite_available():
+        return (
+            "git-cai stats unavailable: this Python build has no sqlite3 "
+            "module. Rebuild Python with sqlite support or set "
+            "`stats: false` to silence this warning."
+        )
+    summary = _aggregate(config, since=since, provider=provider)
+    if as_json:
+        return json.dumps(summary, default=str, indent=2)
+    return render_text(summary)

--- a/src/git_cai_cli/core/validate.py
+++ b/src/git_cai_cli/core/validate.py
@@ -5,7 +5,36 @@ Validation utilities for configuration settings
 import logging
 from typing import Any
 
+import requests
+
 log = logging.getLogger(__name__)
+
+_AUTH_STATUS_CODES = frozenset({401, 403})
+_RATE_LIMIT_STATUS_CODES = frozenset({429})
+
+
+def _extract_api_error_message(response: requests.Response | None) -> str:
+    """Best-effort extraction of an upstream API error body's human message.
+
+    Most providers return JSON like ``{"error": {"message": "...", ...}}``
+    or ``{"error": "..."}``. Falls back to the raw text body if the JSON
+    can't be parsed. Returns an empty string on any failure.
+    """
+    if response is None:
+        return ""
+    try:
+        payload = response.json()
+    except (ValueError, requests.exceptions.JSONDecodeError):
+        text = (response.text or "").strip()
+        return text[:500]
+
+    err = payload.get("error") if isinstance(payload, dict) else None
+    if isinstance(err, dict):
+        msg = err.get("message") or err.get("type") or ""
+        return str(msg).strip()
+    if isinstance(err, str):
+        return err.strip()
+    return ""
 
 
 def _validate_config_keys(config: dict[str, Any], reference: dict[str, Any]) -> None:
@@ -38,7 +67,12 @@ def _validate_config_keys(config: dict[str, Any], reference: dict[str, Any]) -> 
         "pr_to_file",
         "pr_file_name",
         "pr_prompt_file",
+        "stats",
+        "stats_db_path",
     }
+    # Internal escape-hatch keys: accepted if a user sets them, but never
+    # reported as "missing" — they aren't part of the documented surface.
+    internal_only_keys = {"stats_db_path"}
     allowed_provider_keys = set(reference.keys()) - allowed_global_keys
 
     config_keys = set(config.keys())
@@ -50,7 +84,7 @@ def _validate_config_keys(config: dict[str, Any], reference: dict[str, Any]) -> 
         raise KeyError("Unknown config keys: " + ", ".join(sorted(unknown_keys)))
 
     # Info on missing global keys (non-fatal; defaults or global config will be used)
-    missing_globals = allowed_global_keys - config_keys
+    missing_globals = allowed_global_keys - config_keys - internal_only_keys
     if missing_globals:
         log.info(
             "Config does not define: %s. Global or default values will be used.",
@@ -157,38 +191,88 @@ def _validate_llm_call(
     try:
         return fn(*args, **kwargs)
 
-    except Exception as exc:
-        msg = str(exc).lower()
+    except requests.HTTPError as exc:
+        response = exc.response
+        status = response.status_code if response is not None else None
+        api_msg = _extract_api_error_message(response)
 
-        auth_markers = (
-            "api key",
-            "apikey",
-            "authorization",
-            "unauthorized",
-            "forbidden",
-            "400",
-            "401",
-            "403",
-            "invalid token",
-            "invalid api key",
-            "authentication",
-            "permission denied",
-        )
-
-        if any(marker in msg for marker in auth_markers):
-            log.error("LLM authentication failed.")
+        if status in _AUTH_STATUS_CODES:
             log.error(
-                "If this is the first run after installation, this is expected. Please configure your API key."
+                "LLM authentication failed (HTTP %s)%s",
+                status,
+                f": {api_msg}" if api_msg else ".",
             )
             raise ValueError(
-                "API token is invalid or not authorized. Please check your API key."
-                "If error 400, 401, or 403 is mentioned, it often indicates an authentication issue."
-                "Sometimes waiting a Mintute and trying again can resolve transient issues, especially with new API keys."
-                "If the problem persists, please verify your API key and its permissions."
+                f"API token is invalid or not authorized (HTTP {status}). "
+                f"{api_msg or 'Please check your API key and its permissions.'}"
             ) from None
 
+        if status in _RATE_LIMIT_STATUS_CODES:
+            log.error(
+                "LLM rate limit hit (HTTP %s)%s",
+                status,
+                f": {api_msg}" if api_msg else ".",
+            )
+            raise ValueError(
+                f"Rate limit exceeded (HTTP {status}). "
+                f"{api_msg or 'Please wait a minute and retry.'}"
+            ) from None
+
+        log.exception("LLM call failed (HTTP %s).", status)
+        raise ValueError(
+            f"LLM call failed (HTTP {status})."
+            + (f" Upstream message: {api_msg}" if api_msg else "")
+        ) from None
+
+    except Exception:
+        # Unexpected non-HTTP error — preserve the original traceback.
+        # OpenAI-SDK paths surface their own exception classes whose
+        # ``status_code`` attribute (when present) is checked by the
+        # SDK-aware caller. Here we just log and re-raise so debug mode
+        # users see the full stack.
+        sdk_status = _openai_sdk_status_code()
+        if sdk_status is not None:
+            # Re-raise as ValueError with classification consistent with
+            # the requests path so user-facing flow is uniform.
+            if sdk_status in _AUTH_STATUS_CODES:
+                log.error("LLM authentication failed (SDK status %s).", sdk_status)
+                raise ValueError(
+                    f"API token is invalid or not authorized (status {sdk_status}). "
+                    "Please check your API key and its permissions."
+                ) from None
+            if sdk_status in _RATE_LIMIT_STATUS_CODES:
+                log.error("LLM rate limit hit (SDK status %s).", sdk_status)
+                raise ValueError(
+                    f"Rate limit exceeded (status {sdk_status}). "
+                    "Please wait a minute and retry."
+                ) from None
         log.exception("Unexpected error during LLM execution.")
         raise
+
+
+def _openai_sdk_status_code() -> int | None:
+    """Return the HTTP status code from the in-flight OpenAI SDK exception,
+    if one is currently being handled. Returns None otherwise.
+
+    Done lazily so importing ``openai`` is not required when only
+    ``requests``-based providers are used.
+    """
+    import sys
+
+    exc = sys.exc_info()[1]
+    if exc is None:
+        return None
+
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            return status
+    return None
 
 
 def _validate_style(style: str | None) -> str:

--- a/src/git_cai_cli/main.py
+++ b/src/git_cai_cli/main.py
@@ -51,23 +51,39 @@ def ensure_git_alias() -> None:
         raise typer.Exit(code=1)
 
 
+def _log_stats_state(config: dict) -> None:
+    """Backwards-compatible wrapper around ``stats.log_state``.
+
+    The implementation moved into ``core.stats`` to break a cyclic
+    import (``core.pr`` / ``core.squash`` used to import this from
+    ``main``). Kept here so existing test imports continue to work.
+    """
+    from git_cai_cli.core import stats as stats_module
+
+    stats_module.log_state(config)
+
+
 def run(
     *,
     mode: Mode,
     enable_debug: bool,
     list_arg: str | None,
     stage_tracked: bool,
-    conventional: bool = False,
-    branch_context: bool = False,
+    conventional: bool | None = None,
+    branch_context: bool | None = None,
     crazy: bool,
     provider_override: str | None = None,
     model_override: str | None = None,
     time_flag: bool = False,
     context: str | None = None,
     timeout_override: int | None = None,
-    full_files_override: bool = False,
+    full_files_override: bool | None = None,
     files_override: list[str] | None = None,
     base_override: str | None = None,
+    sql_override: bool | None = None,
+    stats_since: str | None = None,
+    stats_json: bool = False,
+    stats_reset: bool = False,
 ) -> None:
     """
     Main function to run the Git CAI CLI tool.
@@ -90,6 +106,7 @@ def run(
         find_git_root,
         get_last_commit_diff,
         git_diff_excluding,
+        repo_name_from_root,
     )
     from git_cai_cli.core.llm import CommitMessageGenerator
     from git_cai_cli.core.options import CliManager
@@ -113,6 +130,7 @@ def run(
             time_flag=time_flag,
             squash_arg=list_arg,
             context=context,
+            sql_override=sql_override,
         )
         return
 
@@ -125,11 +143,23 @@ def run(
             time_flag=time_flag,
             base_override=base_override,
             context=context,
+            sql_override=sql_override,
         )
         return
 
     if mode is Mode.UPDATE:
         manager.check_and_update()
+        return
+
+    if mode is Mode.STATS:
+        from git_cai_cli.core import stats
+
+        config = load_config()
+        if stats_reset:
+            removed = stats.reset(config)
+            typer.echo(f"Cleared {removed} stats event(s).")
+            return
+        typer.echo(stats.show(config, since=stats_since, as_json=stats_json))
         return
 
     is_amend = mode is Mode.AMEND
@@ -148,14 +178,16 @@ def run(
         branch_context=branch_context,
         timeout_override=timeout_override,
         full_files_override=full_files_override,
+        sql_override=sql_override,
     )
 
+    _log_stats_state(config)
+
+    branch_name: str | None = None
     if config.get("branch_context", False):
         from git_cai_cli.core.gitutils import get_current_branch
 
         branch_name = get_current_branch()
-        if branch_name:
-            config["branch_name"] = branch_name
 
     provider = config["default"]
     token = load_token(config=config)
@@ -188,7 +220,9 @@ def run(
     measure = time_flag or config.get("measure_time", False)
     start = time.perf_counter() if measure else None
 
-    generator = CommitMessageGenerator(token, config, provider)
+    generator = CommitMessageGenerator(token, config, provider, branch_name=branch_name)
+    generator.kind = "amend" if is_amend else "commit"
+    generator.repo = repo_name_from_root(repo_root)
     try:
         try:
             spinner_text = (
@@ -213,6 +247,7 @@ def run(
     if start is not None:
         elapsed = time.perf_counter() - start
         log.info("Commit message generated in %.2fs", elapsed)
+        generator.record_elapsed(int(elapsed * 1000))
 
     if crazy:
         rc = manager.commit_crazy(commit_message, amend=is_amend)

--- a/tests/unit/test_branch_context.py
+++ b/tests/unit/test_branch_context.py
@@ -15,12 +15,12 @@ def _make_generator(branch_context=False, branch_name=""):
         "emoji": True,
         "conventional": False,
         "branch_context": branch_context,
-        "branch_name": branch_name,
     }
     return CommitMessageGenerator(
         token="fake-token",
         config=config,
         default_model="openai",
+        branch_name=branch_name or None,
     )
 
 
@@ -76,3 +76,15 @@ def test_default_config_contains_branch_context():
     """DEFAULT_CONFIG should include branch_context key set to False."""
     assert "branch_context" in DEFAULT_CONFIG
     assert DEFAULT_CONFIG["branch_context"] is False
+
+
+def test_branch_name_does_not_leak_into_config():
+    """F1.6 regression: branch name is constructor state, not config.
+
+    The previous implementation stuffed branch_name into the config
+    dict so it surfaced in `git cai -l config` output. It must now live
+    on the generator instance only.
+    """
+    gen = _make_generator(branch_context=True, branch_name="feat/x")
+    assert "branch_name" not in gen.config
+    assert gen.branch_name == "feat/x"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -265,8 +265,9 @@ def test_branch_short_flag_passed_to_run(monkeypatch):
     assert captured["branch_context"] is True
 
 
-def test_branch_false_by_default(monkeypatch):
-    """Verify branch_context is False when not provided."""
+def test_branch_none_by_default(monkeypatch):
+    """When neither --branch nor --no-branch is passed, branch_context is
+    None so the persisted config value wins (Optional[bool] semantics)."""
     captured = {}
 
     def _fake_run(**kwargs):
@@ -276,6 +277,21 @@ def test_branch_false_by_default(monkeypatch):
     monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
 
     result = runner.invoke(cli.app, [])
+    assert result.exit_code == 0
+    assert captured["branch_context"] is None
+
+
+def test_no_branch_flag_sets_false(monkeypatch):
+    """--no-branch must explicitly disable branch_context (override true config)."""
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "run", _fake_run)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, ["--no-branch"])
     assert result.exit_code == 0
     assert captured["branch_context"] is False
 
@@ -380,8 +396,9 @@ def test_short_full_files_flag_passed_to_run(monkeypatch):
     assert captured["full_files_override"] is True
 
 
-def test_full_files_false_by_default(monkeypatch):
-    """Verify full_files_override is False when flag absent."""
+def test_full_files_none_by_default(monkeypatch):
+    """When neither --full-files nor --no-full-files is passed,
+    full_files_override is None so the persisted config wins."""
     captured = {}
 
     def _fake_run(**kwargs):
@@ -391,6 +408,21 @@ def test_full_files_false_by_default(monkeypatch):
     monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
 
     result = runner.invoke(cli.app, [])
+    assert result.exit_code == 0
+    assert captured["full_files_override"] is None
+
+
+def test_no_full_files_flag_sets_false(monkeypatch):
+    """--no-full-files must explicitly disable full-files (override true config)."""
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "run", _fake_run)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, ["--no-full-files"])
     assert result.exit_code == 0
     assert captured["full_files_override"] is False
 
@@ -459,3 +491,77 @@ def test_files_flag_passed_to_validate_options(monkeypatch):
     result = runner.invoke(cli.app, ["-f", "x.py"])
     assert result.exit_code == 0
     assert captured["files"] == ["x.py"]
+
+
+# ---------------------------------------------------------------------------
+# FB.11 — --sql / -q value-form override + --stats viewer
+# ---------------------------------------------------------------------------
+
+
+def test_sql_true_threads_through_to_run(monkeypatch):
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "run", _fake_run)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, ["--sql", "true"])
+    assert result.exit_code == 0
+    assert captured["sql_override"] is True
+
+
+def test_sql_false_threads_through_to_run(monkeypatch):
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "run", _fake_run)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, ["-q", "false"])
+    assert result.exit_code == 0
+    assert captured["sql_override"] is False
+
+
+def test_sql_invalid_value_errors(monkeypatch):
+    """--sql must reject anything that isn't a boolean string."""
+    monkeypatch.setattr(cli, "run", lambda **kwargs: None)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, ["--sql", "maybe"])
+    assert result.exit_code != 0
+    assert "true/false" in result.output
+
+
+def test_sql_absent_passes_none(monkeypatch):
+    """When --sql is omitted, sql_override is None (no per-run override)."""
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "run", _fake_run)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, [])
+    assert result.exit_code == 0
+    assert captured["sql_override"] is None
+
+
+def test_no_conventional_flag_threads_to_run(monkeypatch):
+    """--no-conventional must thread False through to run() so a persisted
+    `conventional: true` can be overridden for a single invocation (F0.3)."""
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "run", _fake_run)
+    monkeypatch.setattr(cli, "validate_options", lambda **kwargs: None)
+
+    result = runner.invoke(cli.app, ["--no-conventional"])
+    assert result.exit_code == 0
+    assert captured["conventional"] is False

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -117,7 +117,13 @@ def test_repo_config_precedence(tmp_path):
     with patch("git_cai_cli.core.config.find_git_root", return_value=tmp_path):
         config = load_config(fallback_config_file=fallback)
 
+    # Repo config wins for every key it defines; `stats` is the one
+    # exception and falls through to the home config.
+    home_stats = config.pop("stats", None)
     assert config == repo_data
+    assert home_stats == DEFAULT_CONFIG["stats"]
+    # The default is the flat boolean, not a nested dict.
+    assert home_stats is False
 
 
 def test_load_token_creates_template(tmp_path):
@@ -472,11 +478,32 @@ def test_apply_cli_overrides_full_files_true_sets_true():
     assert cfg["full_files"] is True
 
 
-def test_apply_cli_overrides_full_files_false_preserves_true_config():
-    """Absence of the flag must not clobber a config-level `full_files: true`."""
+def test_apply_cli_overrides_none_preserves_true_config():
+    """``None`` (no flag passed) must not clobber a config-level `full_files: true`."""
+    cfg = {"full_files": True}
+    apply_cli_overrides(cfg, full_files_override=None)
+    assert cfg["full_files"] is True
+
+
+def test_apply_cli_overrides_full_files_false_overrides_true_config():
+    """Explicit ``--no-full-files`` must flip a persisted `full_files: true` off."""
     cfg = {"full_files": True}
     apply_cli_overrides(cfg, full_files_override=False)
-    assert cfg["full_files"] is True
+    assert cfg["full_files"] is False
+
+
+def test_apply_cli_overrides_conventional_false_overrides_true_config():
+    """Explicit ``--no-conventional`` must flip a persisted `conventional: true` off."""
+    cfg = {"conventional": True}
+    apply_cli_overrides(cfg, conventional=False)
+    assert cfg["conventional"] is False
+
+
+def test_apply_cli_overrides_branch_context_false_overrides_true_config():
+    """Explicit ``--no-branch`` must flip a persisted `branch_context: true` off."""
+    cfg = {"branch_context": True}
+    apply_cli_overrides(cfg, branch_context=False)
+    assert cfg["branch_context"] is False
 
 
 def test_apply_cli_overrides_all_flags_at_once():
@@ -494,3 +521,204 @@ def test_apply_cli_overrides_all_flags_at_once():
         "timeout": 75,
         "full_files": True,
     }
+
+
+# ---------------------------------------------------------------------------
+# `git cai -g` must include the `stats` block in the generated config
+# ---------------------------------------------------------------------------
+
+
+def test_ordered_default_config_includes_stats():
+    from git_cai_cli.core.config import DEFAULT_CONFIG, ordered_default_config
+
+    ordered = ordered_default_config()
+    assert "stats" in ordered
+    assert ordered["stats"] == DEFAULT_CONFIG["stats"]
+    assert ordered["stats"] is False
+
+
+def test_generated_config_yaml_contains_stats(tmp_path):
+    """The YAML written by `git cai -g` must surface the stats setting
+    as a flat boolean so users see and can toggle it."""
+    import yaml
+    from git_cai_cli.core.options import CliManager
+
+    manager = CliManager(package_name="git-cai-cli")
+    target = tmp_path / "cai_config.yml"
+
+    cwd = tmp_path
+    import os
+
+    prev = os.getcwd()
+    os.chdir(cwd)
+    try:
+        manager.generate_config_here(filename=str(target))
+    finally:
+        os.chdir(prev)
+
+    with target.open() as f:
+        loaded = yaml.safe_load(f)
+
+    assert "stats" in loaded
+    assert loaded["stats"] is False
+
+
+# ---------------------------------------------------------------------------
+# stats fallback chain: repo > home > hardcoded false
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_repo_without_stats_falls_back_to_home(tmp_path, monkeypatch):
+    """If the repo config exists but lacks `stats`, load_config must
+    pull the `stats` block from the home config so users don't lose
+    their global analytics preference per-repo."""
+    import yaml
+    from git_cai_cli.core import config as config_module
+
+    # Repo config — no `stats` key
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo_config = repo_dir / "cai_config.yml"
+    repo_config.write_text(
+        yaml.safe_dump(
+            {
+                "openai": {"model": "gpt-5.1", "temperature": 0},
+                "default": "openai",
+                "language": "en",
+                "style": "professional",
+                "emoji": True,
+                "load_tokens_from": "/tmp/tokens.yml",
+                "prompt_file": "",
+                "squash_prompt_file": "",
+            }
+        )
+    )
+
+    # Home config — defines stats
+    home_config = tmp_path / "home_cai_config.yml"
+    home_config.write_text(yaml.safe_dump({"stats": True}))
+
+    monkeypatch.chdir(repo_dir)
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: repo_config)
+
+    result = config_module.load_config(fallback_config_file=home_config)
+
+    assert result["stats"] is True
+
+
+def test_load_config_repo_with_stats_does_not_fall_back(tmp_path, monkeypatch):
+    """If the repo config defines `stats`, the repo value wins —
+    home config is not consulted."""
+    import yaml
+    from git_cai_cli.core import config as config_module
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo_config = repo_dir / "cai_config.yml"
+    repo_config.write_text(
+        yaml.safe_dump(
+            {
+                "openai": {"model": "gpt-5.1", "temperature": 0},
+                "default": "openai",
+                "language": "en",
+                "style": "professional",
+                "emoji": True,
+                "load_tokens_from": "/tmp/tokens.yml",
+                "prompt_file": "",
+                "squash_prompt_file": "",
+                "stats": False,
+            }
+        )
+    )
+
+    home_config = tmp_path / "home_cai_config.yml"
+    home_config.write_text(yaml.safe_dump({"stats": True}))
+
+    monkeypatch.chdir(repo_dir)
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: repo_config)
+
+    result = config_module.load_config(fallback_config_file=home_config)
+
+    # Repo wins
+    assert result["stats"] is False
+
+
+def test_load_config_no_stats_anywhere_means_disabled(tmp_path, monkeypatch):
+    """Repo config has no stats, home config has no stats — the
+    hardcoded default kicks in via stats.is_enabled."""
+    import yaml
+    from git_cai_cli.core import config as config_module
+    from git_cai_cli.core import stats as stats_module
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo_config = repo_dir / "cai_config.yml"
+    repo_config.write_text(
+        yaml.safe_dump(
+            {
+                "openai": {"model": "gpt-5.1", "temperature": 0},
+                "default": "openai",
+                "language": "en",
+                "style": "professional",
+                "emoji": True,
+                "load_tokens_from": "/tmp/tokens.yml",
+                "prompt_file": "",
+                "squash_prompt_file": "",
+            }
+        )
+    )
+
+    home_config = tmp_path / "home_cai_config.yml"  # absent on disk
+
+    monkeypatch.chdir(repo_dir)
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: repo_config)
+
+    result = config_module.load_config(fallback_config_file=home_config)
+
+    # No `stats` key in repo, no home file → key absent in loaded config
+    assert "stats" not in result
+    # Hardcoded default → False
+    assert stats_module.is_enabled(result) is False
+
+
+def test_load_home_stats_returns_none_when_home_missing(tmp_path):
+    from git_cai_cli.core.config import _load_home_stats
+
+    assert _load_home_stats(tmp_path / "absent.yml") is None
+
+
+def test_load_home_stats_returns_none_when_block_missing(tmp_path):
+    import yaml
+    from git_cai_cli.core.config import _load_home_stats
+
+    home = tmp_path / "home.yml"
+    home.write_text(yaml.safe_dump({"language": "en"}))
+
+    assert _load_home_stats(home) is None
+
+
+def test_load_home_stats_returns_dict_when_present(tmp_path):
+    """When home config defines `stats` and/or `stats_db_path`, the
+    helper returns a dict with whichever keys are set so the caller
+    can merge them."""
+    import yaml
+    from git_cai_cli.core.config import _load_home_stats
+
+    home = tmp_path / "home.yml"
+    home.write_text(yaml.safe_dump({"stats": True, "stats_db_path": "/tmp/x.db"}))
+
+    block = _load_home_stats(home)
+    assert block == {"stats": True, "stats_db_path": "/tmp/x.db"}
+
+
+def test_load_home_stats_partial_returns_only_present_keys(tmp_path):
+    """If only `stats` (or only `stats_db_path`) is in home, only that
+    key is returned."""
+    import yaml
+    from git_cai_cli.core.config import _load_home_stats
+
+    home = tmp_path / "home.yml"
+    home.write_text(yaml.safe_dump({"stats_db_path": "/tmp/x.db"}))
+
+    block = _load_home_stats(home)
+    assert block == {"stats_db_path": "/tmp/x.db"}

--- a/tests/unit/test_gitutils.py
+++ b/tests/unit/test_gitutils.py
@@ -508,3 +508,45 @@ def test_commit_with_edit_template_runs_git_commit(tmp_path):
 
         rc = commit_with_edit_template("initial\n")
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# F1.4 — .caiignore must use gitignore semantics, not bare fnmatch
+# ---------------------------------------------------------------------------
+
+
+from git_cai_cli.core.gitutils import _matches_caiignore as _ci_matches  # noqa: E402
+
+
+def test_caiignore_double_star_recurses():
+    """`**/foo` must match `foo`, `a/foo`, and `a/b/foo` — fnmatch did not."""
+    patterns = ["**/foo.txt"]
+    assert _ci_matches("foo.txt", patterns)
+    assert _ci_matches("a/foo.txt", patterns)
+    assert _ci_matches("a/b/c/foo.txt", patterns)
+
+
+def test_caiignore_negation_re_includes():
+    """`!pattern` re-includes a previously-excluded path."""
+    patterns = ["*.log", "!keep.log"]
+    assert _ci_matches("a.log", patterns)
+    assert not _ci_matches("keep.log", patterns)
+
+
+def test_caiignore_directory_anchored_pattern_only_matches_root():
+    """`/foo` matches at the repo root only — not in subdirectories."""
+    patterns = ["/foo.txt"]
+    assert _ci_matches("foo.txt", patterns)
+    assert not _ci_matches("sub/foo.txt", patterns)
+
+
+def test_caiignore_unanchored_pattern_matches_anywhere():
+    """`foo` (no leading slash) matches at any depth."""
+    patterns = ["foo.txt"]
+    assert _ci_matches("foo.txt", patterns)
+    assert _ci_matches("a/foo.txt", patterns)
+
+
+def test_caiignore_empty_patterns_no_match():
+    """Empty pattern list never matches."""
+    assert not _ci_matches("anything.txt", [])

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -173,7 +173,7 @@ def test_generate_anthropic():
         "content": [{"text": "   test   "}],
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         result = gen.generate_anthropic("abc", system_prompt_override="sys")
 
     assert result == "test"
@@ -230,7 +230,7 @@ def test_generate_gemini():
         "candidates": [{"content": {"parts": [{"text": "   gemini text   "}]}}]
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         result = gen.generate_gemini("abc", system_prompt_override="sys")
 
     assert result == "gemini text"
@@ -283,7 +283,7 @@ def test_generate_groq():
         "choices": [{"message": {"content": "   groq result   "}}]
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         result = gen.generate_groq("abc", system_prompt_override="sys")
 
     assert result == "groq result"
@@ -335,7 +335,7 @@ def test_generate_xai():
         "choices": [{"message": {"content": "   xai content   "}}]
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         result = gen.generate_xai("hello x", system_prompt_override="sys")
 
     assert result == "xai content"
@@ -392,7 +392,7 @@ def test_generate_ollama():
         patch.dict(f"{module_path}.os.environ", {}, clear=True),
         patch(f"{module_path}.shutil.which", return_value="/usr/bin/ollama"),
         patch(f"{module_path}.requests.get", return_value=MagicMock(status_code=200)),
-        patch(f"{module_path}.requests.post", mock_post),
+        patch(f"{module_path}._http_post", mock_post),
     ):
         result = gen.generate_ollama("abc", system_prompt_override="sys")
 
@@ -453,7 +453,7 @@ def test_generate_ollama_autostarts_and_stops_server():
         patch.dict(f"{module_path}.os.environ", {}, clear=True),
         patch(f"{module_path}.shutil.which", return_value="/usr/bin/ollama"),
         patch(f"{module_path}.requests.get", mock_get),
-        patch(f"{module_path}.requests.post", mock_post),
+        patch(f"{module_path}._http_post", mock_post),
         patch(f"{module_path}.subprocess.Popen", return_value=proc) as popen,
         patch(f"{module_path}.os.killpg") as killpg,
     ):
@@ -515,7 +515,7 @@ def test_token_usage_logged_anthropic(caplog):
     }
 
     with caplog.at_level(logging.INFO):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_anthropic("diff", system_prompt_override="sys")
 
     assert (
@@ -540,7 +540,7 @@ def test_token_usage_logged_gemini(caplog):
     }
 
     with caplog.at_level(logging.INFO):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_gemini("diff", system_prompt_override="sys")
 
     assert "Token usage [gemini]: prompt=150, completion=60, total=210" in caplog.text
@@ -563,7 +563,7 @@ def test_token_usage_logged_groq(caplog):
     }
 
     with caplog.at_level(logging.INFO):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_groq("diff", system_prompt_override="sys")
 
     assert "Token usage [groq]: prompt=120, completion=40, total=160" in caplog.text
@@ -596,7 +596,7 @@ def test_token_usage_logged_ollama(caplog):
                 f"{module_path}.requests.get",
                 return_value=MagicMock(status_code=200),
             ),
-            patch(f"{module_path}.requests.post", mock_post),
+            patch(f"{module_path}._http_post", mock_post),
         ):
             gen.generate_ollama("diff", system_prompt_override="sys")
 
@@ -620,7 +620,7 @@ def test_token_usage_not_available(caplog):
     }
 
     with caplog.at_level(logging.DEBUG):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_groq("diff", system_prompt_override="sys")
 
     assert "Token usage not available" in caplog.text
@@ -643,7 +643,7 @@ def test_token_usage_disabled(caplog):
     }
 
     with caplog.at_level(logging.DEBUG):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_groq("diff", system_prompt_override="sys")
 
     assert "Token usage" not in caplog.text
@@ -666,7 +666,7 @@ def test_token_usage_disabled_when_key_missing(caplog):
     }
 
     with caplog.at_level(logging.DEBUG):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_groq("diff", system_prompt_override="sys")
 
     assert "Token usage" not in caplog.text
@@ -699,7 +699,7 @@ def test_generate_mistral():
         "choices": [{"message": {"content": "   mistral result   "}}]
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         result = gen.generate_mistral("abc", system_prompt_override="sys")
 
     assert result == "mistral result"
@@ -749,7 +749,7 @@ def test_generate_mistral_raises_on_http_error():
         "401 Unauthorized"
     )
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         with pytest.raises(requests.HTTPError):
             gen.generate_mistral("abc", system_prompt_override="sys")
 
@@ -771,7 +771,7 @@ def test_token_usage_logged_mistral(caplog):
     }
 
     with caplog.at_level(logging.INFO):
-        with patch(f"{module_path}.requests.post", mock_post):
+        with patch(f"{module_path}._http_post", mock_post):
             gen.generate_mistral("diff", system_prompt_override="sys")
 
     assert "Token usage [mistral]: prompt=110, completion=45, total=155" in caplog.text
@@ -859,7 +859,7 @@ def test_generate_mistral_none_system_prompt_omits_system_message():
         "choices": [{"message": {"content": "msg"}}],
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         gen.generate_mistral("diff", system_prompt_override=None)
 
     call_kwargs = mock_post.call_args[1]
@@ -882,7 +882,7 @@ def test_generate_xai_none_system_prompt_omits_system_message():
         "choices": [{"message": {"content": "msg"}}],
     }
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         gen.generate_xai("diff", system_prompt_override=None)
 
     call_kwargs = mock_post.call_args[1]
@@ -920,7 +920,7 @@ def test_generate_xai_raises_on_http_error():
         "403 Forbidden"
     )
 
-    with patch(f"{module_path}.requests.post", mock_post):
+    with patch(f"{module_path}._http_post", mock_post):
         with pytest.raises(requests.HTTPError):
             gen.generate_xai("abc", system_prompt_override="sys")
 
@@ -1059,7 +1059,7 @@ def test_generate_anthropic_uses_configured_max_tokens():
     mock_post = MagicMock()
     mock_post.return_value.json.return_value = {"content": [{"text": "ok"}]}
 
-    with patch(f"{CommitMessageGenerator.__module__}.requests.post", mock_post):
+    with patch(f"{CommitMessageGenerator.__module__}._http_post", mock_post):
         gen.generate_anthropic("abc", system_prompt_override="sys")
 
     _, kwargs = mock_post.call_args
@@ -1072,7 +1072,7 @@ def test_generate_anthropic_defaults_max_tokens_to_32768():
     mock_post = MagicMock()
     mock_post.return_value.json.return_value = {"content": [{"text": "ok"}]}
 
-    with patch(f"{CommitMessageGenerator.__module__}.requests.post", mock_post):
+    with patch(f"{CommitMessageGenerator.__module__}._http_post", mock_post):
         gen.generate_anthropic("abc", system_prompt_override="sys")
 
     _, kwargs = mock_post.call_args
@@ -1123,7 +1123,7 @@ def test_remote_providers_respect_configured_timeout(
     mock_post = MagicMock()
     mock_post.return_value.json.return_value = response_json
 
-    with patch(f"{CommitMessageGenerator.__module__}.requests.post", mock_post):
+    with patch(f"{CommitMessageGenerator.__module__}._http_post", mock_post):
         getattr(gen, f"generate_{provider}")("abc", system_prompt_override="sys")
 
     _, kwargs = mock_post.call_args
@@ -1148,7 +1148,7 @@ def test_generate_ollama_uses_ollama_timeout():
         patch.dict(f"{module_path}.os.environ", {}, clear=True),
         patch(f"{module_path}.shutil.which", return_value="/usr/bin/ollama"),
         patch(f"{module_path}.requests.get", return_value=MagicMock(status_code=200)),
-        patch(f"{module_path}.requests.post", mock_post),
+        patch(f"{module_path}._http_post", mock_post),
     ):
         gen.generate_ollama("abc", system_prompt_override="sys")
 
@@ -1172,3 +1172,156 @@ def test_generate_openai_sdk_receives_timeout():
     fake_openai_cls.assert_called_once()
     _, kwargs = fake_openai_cls.call_args
     assert kwargs["timeout"] == 55
+
+
+# ---------------------------------------------------------------------------
+# F0.4 — retry/backoff layer for transient HTTP failures
+# ---------------------------------------------------------------------------
+
+
+def test_retry_session_configures_status_forcelist():
+    """The session's adapter must retry on 429 and the 5xx codes that
+    typically signal transient upstream failures. Verifies the config
+    contract directly because requests-mock intercepts above the
+    urllib3 retry layer and would bypass the actual retry machinery."""
+    from git_cai_cli.core.llm import _build_retrying_session
+
+    session = _build_retrying_session()
+    adapter = session.get_adapter("https://example.com/")
+    retry = adapter.max_retries
+
+    for code in (429, 500, 502, 503, 504):
+        assert code in retry.status_forcelist, f"{code} must be retried"
+
+
+def test_retry_session_allows_retries_on_post():
+    """POST must be in the allowed retry methods — provider calls are POSTs."""
+    from git_cai_cli.core.llm import _build_retrying_session
+
+    session = _build_retrying_session()
+    adapter = session.get_adapter("https://example.com/")
+    allowed = {m.upper() for m in adapter.max_retries.allowed_methods}
+    assert "POST" in allowed
+    assert "GET" in allowed
+
+
+def test_retry_session_uses_backoff_and_finite_attempts():
+    """Retry config must have a positive backoff and a small bounded total
+    so a permanently-down provider fails the commit, not hangs forever."""
+    from git_cai_cli.core.llm import _build_retrying_session
+
+    session = _build_retrying_session()
+    adapter = session.get_adapter("https://example.com/")
+    retry = adapter.max_retries
+
+    assert retry.total is not None and retry.total >= 1
+    assert retry.backoff_factor is not None and retry.backoff_factor > 0
+    # Don't raise inside urllib3 — we want validate.py to classify the
+    # final HTTPError.
+    assert retry.raise_on_status is False
+
+
+def test_http_post_routes_through_retrying_session(monkeypatch):
+    """The provider-facing helper _http_post must use the retrying
+    session, not raw requests.post."""
+    import git_cai_cli.core.llm as llm_module
+
+    # Reset the lru-cached session so we observe a fresh build
+    llm_module._get_http_session.cache_clear()
+
+    captured = {}
+    real_get_session = llm_module._get_http_session
+
+    def spy_get_session():
+        s = real_get_session()
+        captured["session"] = s
+        return s
+
+    monkeypatch.setattr(llm_module, "_get_http_session", spy_get_session)
+
+    sentinel = MagicMock(name="response")
+
+    def fake_post(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(llm_module, "_get_http_session", spy_get_session)
+    spy_get_session().post = fake_post  # type: ignore[method-assign]
+
+    result = llm_module._http_post("https://x", json={"a": 1}, timeout=5)
+
+    assert result is sentinel
+    assert captured["args"] == ("https://x",)
+    assert captured["kwargs"] == {"json": {"a": 1}, "timeout": 5}
+
+
+# ---------------------------------------------------------------------------
+# F1.7 — max_output_tokens config (anthropic), backward-compatible with max_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_max_output_tokens_overrides_max_tokens():
+    """max_output_tokens (canonical) wins over the legacy max_tokens key."""
+    config = {
+        "anthropic": {
+            "model": "m",
+            "temperature": 0,
+            "max_tokens": 1000,
+            "max_output_tokens": 5000,
+        }
+    }
+    gen = CommitMessageGenerator(token="t", config=config, default_model="anthropic")
+
+    mock_post = MagicMock()
+    mock_post.return_value.json.return_value = {"content": [{"text": "ok"}]}
+
+    with patch(f"{CommitMessageGenerator.__module__}._http_post", mock_post):
+        gen.generate_anthropic("abc", system_prompt_override="sys")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"]["max_tokens"] == 5000
+
+
+def test_anthropic_legacy_max_tokens_still_works():
+    """Existing user configs that only use max_tokens must keep working."""
+    config = {"anthropic": {"model": "m", "temperature": 0, "max_tokens": 7777}}
+    gen = CommitMessageGenerator(token="t", config=config, default_model="anthropic")
+
+    mock_post = MagicMock()
+    mock_post.return_value.json.return_value = {"content": [{"text": "ok"}]}
+
+    with patch(f"{CommitMessageGenerator.__module__}._http_post", mock_post):
+        gen.generate_anthropic("abc", system_prompt_override="sys")
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"]["max_tokens"] == 7777
+
+
+# ---------------------------------------------------------------------------
+# F1.3 — Ollama startup timeout config + Windows gate
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_startup_timeout_uses_config_value():
+    config = {"ollama": {"model": "llama3", "temperature": 0, "startup_timeout": 30}}
+    gen = CommitMessageGenerator(token=None, config=config, default_model="ollama")
+    assert gen._ollama_startup_timeout() == 30.0
+
+
+def test_ollama_startup_timeout_default():
+    config = {"ollama": {"model": "llama3", "temperature": 0}}
+    gen = CommitMessageGenerator(token=None, config=config, default_model="ollama")
+    assert gen._ollama_startup_timeout() == 8.0
+
+
+def test_ollama_start_skips_start_new_session_on_windows(monkeypatch, generator):
+    """On Windows, start_new_session is invalid and would raise; the
+    code must omit it."""
+    import git_cai_cli.core.llm as llm_module
+
+    monkeypatch.setattr(llm_module.sys, "platform", "win32")
+    monkeypatch.setattr(generator, "_ollama_is_running", lambda: True)
+
+    # Should not raise; running check returns True so Popen isn't called
+    generator._start_ollama_server_if_needed()

--- a/tests/unit/test_prompt_loading.py
+++ b/tests/unit/test_prompt_loading.py
@@ -917,3 +917,59 @@ class TestLanguageStyleEmojiCoverAllPrompts:
         assert "German" in prompt
         assert "funny" in prompt
         assert "emoji" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Base + suffix join uses a blank line, not a single space
+# ---------------------------------------------------------------------------
+
+
+class TestPromptBaseSuffixJoin:
+    """Base prompt files end with a newline; appending the config-driven
+    suffix with a single space used to glue an instruction onto the last
+    line of the base. Joining with a blank line keeps the base intact and
+    visually separates it from the suffix."""
+
+    def _make_gen(self, base_config, prompt_file_key, prompt_path):
+        config = dict(base_config)
+        config[prompt_file_key] = str(prompt_path)
+        return CommitMessageGenerator(
+            token="fake-token", config=config, default_model="openai"
+        )
+
+    def test_commit_prompt_uses_blank_line_between_base_and_suffix(
+        self, tmp_path, base_config
+    ):
+        prompt_file = tmp_path / "base.md"
+        prompt_file.write_text("Base prompt body.\n", encoding="utf-8")
+        gen = self._make_gen(base_config, "prompt_file", prompt_file)
+
+        prompt = gen._build_commit_prompt()
+
+        assert "Base prompt body.\n\n" in prompt
+        assert "Base prompt body. " not in prompt
+        assert "Base prompt body.\n " not in prompt
+
+    def test_squash_prompt_uses_blank_line_between_base_and_suffix(
+        self, tmp_path, base_config
+    ):
+        prompt_file = tmp_path / "squash_base.md"
+        prompt_file.write_text("Squash base body.\n", encoding="utf-8")
+        gen = self._make_gen(base_config, "squash_prompt_file", prompt_file)
+
+        prompt = gen._build_squash_prompt()
+
+        assert "Squash base body.\n\n" in prompt
+        assert "Squash base body. " not in prompt
+
+    def test_pr_prompt_uses_blank_line_between_base_and_suffix(
+        self, tmp_path, base_config
+    ):
+        prompt_file = tmp_path / "pr_base.md"
+        prompt_file.write_text("PR base body.\n", encoding="utf-8")
+        gen = self._make_gen(base_config, "pr_prompt_file", prompt_file)
+
+        prompt = gen._build_pr_prompt()
+
+        assert "PR base body.\n\n" in prompt
+        assert "PR base body. " not in prompt

--- a/tests/unit/test_squash.py
+++ b/tests/unit/test_squash.py
@@ -46,6 +46,8 @@ def clean_git_state() -> typing.Callable:
         """
         Simulates subprocess.check_output side effects for a clean Git state.
         """
+        if cmd[:3] == ["git", "rev-parse", "--is-shallow-repository"]:
+            return "false"
         if cmd[:3] == ["git", "diff", "--cached"]:
             return ""
         if cmd[:2] == ["git", "diff"]:
@@ -80,6 +82,7 @@ def test_aborts_on_unstaged_changes(mock_repo_root) -> None:
         patch(
             "subprocess.check_output",
             side_effect=[
+                "false",  # is-shallow-repository
                 "",  # staged
                 "file.py",  # unstaged
             ],
@@ -101,6 +104,8 @@ def test_commits_staged_changes_first(mock_repo_root, mock_generator) -> None:
         """
         Simulates subprocess.check_output side effects for staged changes.
         """
+        if cmd[:3] == ["git", "rev-parse", "--is-shallow-repository"]:
+            return "false"
         if cmd[:3] == ["git", "diff", "--cached"]:
             return "file.py"
         if cmd[:2] == ["git", "diff"]:
@@ -344,6 +349,8 @@ def test_squash_branch_with_squash_arg(mock_repo_root, mock_generator) -> None:
     run_mock = MagicMock(return_value=MagicMock(returncode=0))
 
     def git_side_effect(cmd, text=True, **kwargs) -> str:
+        if cmd[:3] == ["git", "rev-parse", "--is-shallow-repository"]:
+            return "false"
         if cmd[:3] == ["git", "diff", "--cached"]:
             return ""
         if cmd[:2] == ["git", "diff"]:
@@ -411,3 +418,191 @@ def test_squash_branch_passes_context_to_generator(
 
     call_args = mock_generator.summarize_commit_history.call_args
     assert call_args[1].get("context") == "Closes #42"
+
+
+# ---------------------------------------------------------------------------
+# Editor launch must use argv form (no shell=True) — F0.2 security fix
+# ---------------------------------------------------------------------------
+
+
+def test_editor_launch_uses_argv_never_shell(
+    mock_repo_root, clean_git_state, mock_generator
+) -> None:
+    """
+    The editor must always be launched via argv list. Using shell=True is a
+    code-injection vector if GIT_EDITOR carries shell metacharacters.
+    """
+    run_mock = MagicMock(return_value=MagicMock(returncode=0))
+
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("subprocess.check_output", side_effect=clean_git_state),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.squash.CommitMessageGenerator",
+            return_value=mock_generator,
+        ),
+        patch("git_cai_cli.core.squash.get_git_editor", return_value="true"),
+        patch("git_cai_cli.core.squash.sha256_of_file", side_effect=["a", "b"]),
+        patch("subprocess.run", run_mock),
+        patch("git_cai_cli.core.squash._has_upstream", return_value=False),
+    ):
+        squash_branch()
+
+    for kwargs in (c.kwargs for c in run_mock.call_args_list):
+        assert (
+            kwargs.get("shell", False) is False
+        ), "subprocess.run was invoked with shell=True — security regression"
+
+    editor_calls = [
+        c
+        for c in run_mock.call_args_list
+        if c.args and isinstance(c.args[0], list) and c.args[0][0] == "true"
+    ]
+    assert editor_calls, "expected an argv-form call for the editor invocation"
+
+
+def test_editor_with_shell_metacharacters_is_not_expanded(
+    mock_repo_root, clean_git_state, mock_generator, tmp_path
+) -> None:
+    """
+    A malicious GIT_EDITOR like 'true; rm -rf /' must be parsed by shlex
+    and either rejected (executable 'true; rm -rf /' isn't on PATH) or
+    passed as a single argv[0] — never expanded by a shell.
+    """
+    canary = tmp_path / "should-not-exist.txt"
+    malicious = f"true; touch {canary}"
+
+    run_mock = MagicMock(return_value=MagicMock(returncode=0))
+
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("subprocess.check_output", side_effect=clean_git_state),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.squash.CommitMessageGenerator",
+            return_value=mock_generator,
+        ),
+        patch("git_cai_cli.core.squash.get_git_editor", return_value=malicious),
+        patch("git_cai_cli.core.squash.sha256_of_file", side_effect=["a", "b"]),
+        patch("subprocess.run", run_mock),
+        patch("git_cai_cli.core.squash._has_upstream", return_value=False),
+    ):
+        squash_branch()
+
+    for kwargs in (c.kwargs for c in run_mock.call_args_list):
+        assert kwargs.get("shell", False) is False
+    assert (
+        not canary.exists()
+    ), "shell metacharacters in GIT_EDITOR were expanded — injection vector"
+
+
+def test_editor_not_on_path_aborts_cleanly(
+    mock_repo_root, clean_git_state, mock_generator, caplog
+) -> None:
+    """
+    If the editor binary isn't on PATH, the squash flow logs a clear error
+    and returns — no fallback to shell=True.
+    """
+    run_mock = MagicMock(return_value=MagicMock(returncode=0))
+
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("subprocess.check_output", side_effect=clean_git_state),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.squash.CommitMessageGenerator",
+            return_value=mock_generator,
+        ),
+        patch(
+            "git_cai_cli.core.squash.get_git_editor",
+            return_value="/nonexistent/editor-xyz",
+        ),
+        patch("git_cai_cli.core.squash.sha256_of_file", return_value="hash"),
+        patch("subprocess.run", run_mock),
+        patch("git_cai_cli.core.squash._has_upstream", return_value=False),
+    ):
+        squash_branch()
+
+    assert "not found in PATH" in caplog.text
+    for kwargs in (c.kwargs for c in run_mock.call_args_list):
+        assert kwargs.get("shell", False) is False
+
+
+# ---------------------------------------------------------------------------
+# F1.2 — shallow-clone preflight
+# ---------------------------------------------------------------------------
+
+
+def test_shallow_clone_aborts_with_clear_message(mock_repo_root, caplog) -> None:
+    """A shallow clone must be detected and surfaced clearly so the user
+    isn't left guessing why HEAD~N or merge-base failed."""
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("subprocess.check_output", return_value="true"),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+    ):
+        squash_branch()
+
+    assert "shallow clone" in caplog.text.lower()
+    assert "git fetch --unshallow" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# F1.1 — squash editor cancel surfaces rollback instructions
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_after_staged_commit_surfaces_rollback_instructions(
+    mock_repo_root, mock_generator, caplog
+) -> None:
+    """If the user has staged changes that get committed before the squash
+    summary editor is opened, and they then cancel the editor, we must
+    point them at `git reset HEAD~1 --soft` so they can recover."""
+
+    def git_side_effect(cmd, text=True, **kwargs) -> str:
+        if cmd[:3] == ["git", "rev-parse", "--is-shallow-repository"]:
+            return "false"
+        if cmd[:3] == ["git", "diff", "--cached"]:
+            return "file.py"
+        if cmd[:2] == ["git", "diff"]:
+            return ""
+        if cmd[:2] == ["git", "--no-pager"] and "log" in cmd:
+            return "commit 1\ncommit 2"
+        if "merge-base" in cmd:
+            return "BASE"
+        if "symbolic-ref" in cmd:
+            return "refs/remotes/origin/main"
+        raise AssertionError(f"Unexpected git command: {cmd}")
+
+    caplog.set_level("WARNING")
+
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("git_cai_cli.core.squash.git_diff_excluding", return_value="diff"),
+        patch("subprocess.check_output", side_effect=git_side_effect),
+        patch("git_cai_cli.core.squash.commit_with_edit_template", return_value=1),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.squash.CommitMessageGenerator",
+            return_value=mock_generator,
+        ),
+    ):
+        squash_branch()
+
+    assert "git reset HEAD~1 --soft" in caplog.text

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -1,0 +1,705 @@
+"""FB.11 — git cai stats: local-only usage analytics.
+
+All tests are mocked; no real API calls and no real network.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from git_cai_cli.core import stats as stats_module
+
+
+@pytest.fixture
+def db_config(tmp_path: Path) -> dict:
+    """A config dict whose stats DB lives under tmp_path."""
+    return {
+        "stats": True,
+        "stats_db_path": str(tmp_path / "stats.db"),
+    }
+
+
+def _read_all(db_path: Path) -> list[tuple]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("SELECT * FROM events").fetchall()
+    finally:
+        conn.close()
+
+
+def _read_rows(db_path: Path, columns: str = "*") -> list[dict]:
+    """Read events as a list of dicts so tests aren't coupled to column order."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(f"SELECT {columns} FROM events").fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Opt-in default — stats.enabled defaults to False
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_defaults_to_false():
+    """Stats writing is opt-in: missing config returns False."""
+    assert stats_module.is_enabled(None) is False
+    assert stats_module.is_enabled({}) is False
+    assert stats_module.is_enabled({"stats": False}) is False
+
+
+def test_is_enabled_true_when_explicitly_set():
+    assert stats_module.is_enabled({"stats": True}) is True
+
+
+def test_is_enabled_rejects_legacy_dict_shape(caplog):
+    """Old-style nested config (`stats: {enabled: true}`) is no longer
+    supported: only the flat ``stats: true|false`` boolean form. A
+    dict value is treated as disabled and a deprecation warning is
+    logged once."""
+    stats_module._warn_legacy_stats_shape_once.cache_clear()
+    caplog.set_level("WARNING")
+
+    assert stats_module.is_enabled({"stats": {"enabled": True}}) is False
+    assert "supported form is now a plain boolean" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# record() — best-effort, never raises
+# ---------------------------------------------------------------------------
+
+
+def test_record_writes_event_when_enabled(db_config, tmp_path):
+    event_id = stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="anthropic",
+        model="claude",
+        tokens_in=10,
+        tokens_out=5,
+        latency_ms=1234,
+        repo="git-cai",
+        language="en",
+        style="professional",
+        emoji=True,
+        temperature=0.2,
+        prompt_file="/tmp/p.md",
+    )
+
+    rows = _read_rows(Path(db_config["stats_db_path"]))
+    assert len(rows) == 1
+    row = rows[0]
+    assert event_id == row["id"]
+    assert row["kind"] == "commit"
+    assert row["provider"] == "anthropic"
+    assert row["model"] == "claude"
+    assert row["tokens_in"] == 10
+    assert row["tokens_out"] == 5
+    assert row["latency_ms"] == 1234
+    assert row["success"] == 1
+    assert row["ts"]  # ISO timestamp
+    assert row["repo"] == "git-cai"
+    assert row["language"] == "en"
+    assert row["style"] == "professional"
+    assert row["emoji"] == 1
+    assert row["temperature"] == pytest.approx(0.2)
+    assert row["prompt_file"] == "/tmp/p.md"
+    assert row["time_ms"] is None
+
+
+def test_record_is_noop_when_disabled(tmp_path):
+    """When stats is False, no row is written and no DB created."""
+    db = tmp_path / "stats.db"
+    config = {"stats": False, "stats_db_path": str(db)}
+
+    stats_module.record(
+        config=config,
+        kind="commit",
+        provider="x",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+
+    assert not db.exists()
+
+
+def test_record_swallows_write_errors(tmp_path, caplog):
+    """A bad DB path must NOT bubble up — recording is best-effort."""
+    bad = tmp_path / "nope" / "is" / "a" / "regular" / "file.db"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("not a sqlite db")  # so connect() fails to read schema
+
+    # Make the parent read-only so writes fail noisily
+    config = {"stats": True, "stats_db_path": str(bad)}
+
+    # Should NOT raise. Whether anything is logged is implementation
+    # detail; what matters is no exception leaks.
+    stats_module.record(
+        config=config,
+        kind="commit",
+        provider="x",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# show() / aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_show_text_summary_after_recording(db_config):
+    for prov in ["anthropic", "anthropic", "groq"]:
+        stats_module.record(
+            config=db_config,
+            kind="commit",
+            provider=prov,
+            model="m",
+            tokens_in=100,
+            tokens_out=20,
+            latency_ms=500,
+        )
+
+    out = stats_module.show(db_config, as_json=False)
+
+    assert "Commits generated:" in out
+    assert "anthropic" in out
+    assert "groq" in out
+    assert "Total tokens:" in out
+
+
+def test_show_json_summary(db_config):
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="anthropic",
+        model="m",
+        tokens_in=10,
+        tokens_out=5,
+        latency_ms=100,
+    )
+
+    out = stats_module.show(db_config, as_json=True)
+    parsed = json.loads(out)
+
+    assert parsed["total_commits"] == 1
+    assert parsed["total_tokens_in"] == 10
+    assert parsed["total_tokens_out"] == 5
+    assert parsed["top_provider"] == "anthropic"
+
+
+def test_show_with_no_db_returns_empty_summary(tmp_path):
+    config = {"stats": True, "stats_db_path": str(tmp_path / "nope.db")}
+    parsed = json.loads(stats_module.show(config, as_json=True))
+    assert parsed["total_commits"] == 0
+    assert parsed["per_provider"] == []
+
+
+# ---------------------------------------------------------------------------
+# reset()
+# ---------------------------------------------------------------------------
+
+
+def test_reset_empties_db(db_config):
+    for _ in range(3):
+        stats_module.record(
+            config=db_config,
+            kind="commit",
+            provider="p",
+            model="m",
+            tokens_in=1,
+            tokens_out=1,
+            latency_ms=1,
+        )
+
+    db_path = Path(db_config["stats_db_path"])
+    assert len(_read_all(db_path)) == 3
+
+    removed = stats_module.reset(db_config)
+    assert removed == 3
+    assert _read_all(db_path) == []
+
+
+def test_reset_no_db_returns_zero(tmp_path):
+    config = {"stats": True, "stats_db_path": str(tmp_path / "absent.db")}
+    assert stats_module.reset(config) == 0
+
+
+# ---------------------------------------------------------------------------
+# Privacy regression — no message/diff/path content can be persisted
+# ---------------------------------------------------------------------------
+
+
+def test_privacy_schema_has_no_message_diff_or_path_columns(db_config):
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+    db_path = Path(db_config["stats_db_path"])
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(events)")}
+    finally:
+        conn.close()
+
+    forbidden = {"message", "diff", "content", "filename", "file"}
+    assert cols.isdisjoint(
+        forbidden
+    ), f"events table contains privacy-sensitive columns: {cols & forbidden}"
+
+
+# ---------------------------------------------------------------------------
+# Extended schema (v2): kind variants, repo, settings snapshot, time_ms
+# ---------------------------------------------------------------------------
+
+
+def test_record_persists_kind_variants(db_config):
+    for kind in ("commit", "amend", "squash", "pr"):
+        stats_module.record(
+            config=db_config,
+            kind=kind,
+            provider="p",
+            model="m",
+            tokens_in=1,
+            tokens_out=1,
+            latency_ms=1,
+        )
+
+    rows = _read_rows(Path(db_config["stats_db_path"]), "kind")
+    kinds = sorted(r["kind"] for r in rows)
+    assert kinds == ["amend", "commit", "pr", "squash"]
+
+
+def test_record_persists_repo_name(db_config):
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+        repo="myproj",
+    )
+    rows = _read_rows(Path(db_config["stats_db_path"]), "repo")
+    assert rows[0]["repo"] == "myproj"
+
+
+def test_record_persists_latency_ms(db_config):
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=789,
+    )
+    rows = _read_rows(Path(db_config["stats_db_path"]), "latency_ms")
+    assert rows[0]["latency_ms"] == 789
+
+
+def test_record_persists_settings_snapshot(db_config):
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+        language="de",
+        style="casual",
+        emoji=False,
+        temperature=0.7,
+        prompt_file="~/.config/cai/commit_prompt.md",
+    )
+    rows = _read_rows(Path(db_config["stats_db_path"]))
+    row = rows[0]
+    assert row["language"] == "de"
+    assert row["style"] == "casual"
+    assert row["emoji"] == 0
+    assert row["temperature"] == pytest.approx(0.7)
+    assert row["prompt_file"] == "~/.config/cai/commit_prompt.md"
+
+
+def test_record_settings_default_to_null(db_config):
+    """Unspecified settings stay NULL — they are not silently filled in."""
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+    rows = _read_rows(Path(db_config["stats_db_path"]))
+    row = rows[0]
+    assert row["repo"] is None
+    assert row["language"] is None
+    assert row["style"] is None
+    assert row["emoji"] is None
+    assert row["temperature"] is None
+    assert row["prompt_file"] is None
+    assert row["time_ms"] is None
+
+
+def test_record_returns_event_id(db_config):
+    """The returned id lets callers patch the row later (e.g. set_time_ms)."""
+    event_id = stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+    assert isinstance(event_id, int)
+    assert event_id > 0
+
+
+def test_record_returns_none_when_disabled(tmp_path):
+    """No write → no row id."""
+    config = {"stats": False, "stats_db_path": str(tmp_path / "x.db")}
+    assert (
+        stats_module.record(
+            config=config,
+            kind="commit",
+            provider="p",
+            model="m",
+            tokens_in=1,
+            tokens_out=1,
+            latency_ms=1,
+        )
+        is None
+    )
+
+
+def test_set_time_ms_updates_existing_event(db_config):
+    event_id = stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+    stats_module.set_time_ms(db_config, event_id, 4242)
+
+    rows = _read_rows(Path(db_config["stats_db_path"]), "time_ms")
+    assert rows[0]["time_ms"] == 4242
+
+
+def test_set_time_ms_noop_with_missing_id(db_config):
+    """A None event_id (writer disabled or failed) must not raise or
+    touch the table."""
+    stats_module.set_time_ms(db_config, None, 100)
+    # No DB created, no exception — that's the contract.
+
+
+def test_set_time_ms_noop_when_disabled(tmp_path):
+    """When stats are disabled, set_time_ms is a clean no-op even if a
+    DB happens to exist on disk."""
+    db = tmp_path / "x.db"
+    enabled = {"stats": True, "stats_db_path": str(db)}
+    event_id = stats_module.record(
+        config=enabled,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+
+    disabled = {"stats": False, "stats_db_path": str(db)}
+    stats_module.set_time_ms(disabled, event_id, 999)
+
+    rows = _read_rows(db, "time_ms")
+    assert rows[0]["time_ms"] is None
+
+
+def test_aggregate_counts_each_kind(db_config):
+    """`_aggregate` exposes per-kind totals so the summary doesn't lump
+    squash/pr/amend under 'commit' anymore."""
+    plan = {"commit": 2, "amend": 1, "squash": 3, "pr": 4}
+    for kind, n in plan.items():
+        for _ in range(n):
+            stats_module.record(
+                config=db_config,
+                kind=kind,
+                provider="p",
+                model="m",
+                tokens_in=1,
+                tokens_out=1,
+                latency_ms=1,
+            )
+
+    summary = json.loads(stats_module.show(db_config, as_json=True))
+    assert summary["total_commits"] == 2
+    assert summary["total_amends"] == 1
+    assert summary["total_squashes"] == 3
+    assert summary["total_prs"] == 4
+
+
+# ---------------------------------------------------------------------------
+# SQLite-missing handling
+# ---------------------------------------------------------------------------
+
+
+def test_record_silently_disabled_when_sqlite_missing(monkeypatch, db_config):
+    """If sqlite isn't available, record() must be a clean no-op
+    (no exception, no DB created)."""
+    monkeypatch.setattr(stats_module, "sqlite3", None)
+
+    stats_module.record(
+        config=db_config,
+        kind="commit",
+        provider="p",
+        model="m",
+        tokens_in=1,
+        tokens_out=1,
+        latency_ms=1,
+    )
+
+    assert not Path(db_config["stats_db_path"]).exists()
+
+
+def test_show_when_sqlite_missing_returns_clear_message(monkeypatch, db_config):
+    """The stats subcommand must explain why it's unavailable rather
+    than returning empty output."""
+    monkeypatch.setattr(stats_module, "sqlite3", None)
+
+    msg = stats_module.show(db_config)
+    assert "sqlite3" in msg
+    assert "stats.enabled" in msg or "rebuild" in msg.lower()
+
+
+def test_sqlite_missing_warning_logged_once(monkeypatch, caplog):
+    """The first miss logs a clear warning; subsequent calls don't spam.
+
+    With the lru-cached warn helper, the warning naturally fires exactly
+    once per process — clearing the cache simulates a fresh process.
+    """
+    monkeypatch.setattr(stats_module, "sqlite3", None)
+    stats_module._warn_sqlite_missing_once.cache_clear()
+
+    caplog.set_level("WARNING")
+    assert stats_module._sqlite_available() is False
+    first = caplog.text.count("sqlite3 module is not available")
+    stats_module._sqlite_available()
+    second = caplog.text.count("sqlite3 module is not available")
+
+    assert first == 1
+    assert second == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI override — --sql true/false threading
+# ---------------------------------------------------------------------------
+
+
+def test_apply_cli_overrides_sql_true_enables_writing():
+    from git_cai_cli.core.config import apply_cli_overrides
+
+    cfg: dict = {}
+    apply_cli_overrides(cfg, sql_override=True)
+    assert cfg["stats"] is True
+
+
+def test_apply_cli_overrides_sql_false_disables_writing():
+    from git_cai_cli.core.config import apply_cli_overrides
+
+    cfg: dict = {"stats": True}
+    apply_cli_overrides(cfg, sql_override=False)
+    assert cfg["stats"] is False
+
+
+def test_apply_cli_overrides_sql_none_preserves_config():
+    from git_cai_cli.core.config import apply_cli_overrides
+
+    cfg: dict = {"stats": True}
+    apply_cli_overrides(cfg, sql_override=None)
+    assert cfg["stats"] is True
+
+
+# ---------------------------------------------------------------------------
+# Startup logging — every run announces stats state and DB path
+# ---------------------------------------------------------------------------
+
+
+def test_log_stats_state_enabled_includes_db_path(caplog, tmp_path):
+    """When stats are enabled, the run logs that fact AND the DB path
+    so users always know where their analytics live."""
+    from git_cai_cli.main import _log_stats_state
+
+    config = {"stats": True, "stats_db_path": str(tmp_path / "x.db")}
+
+    caplog.set_level("INFO")
+    _log_stats_state(config)
+
+    assert "Stats writing enabled" in caplog.text
+    assert str(tmp_path / "x.db") in caplog.text
+
+
+def test_log_stats_state_disabled_says_disabled(caplog):
+    """When stats are off, the disabled state is also surfaced."""
+    from git_cai_cli.main import _log_stats_state
+
+    caplog.set_level("INFO")
+    _log_stats_state({"stats": False})
+
+    assert "Stats writing disabled" in caplog.text
+
+
+def test_log_stats_state_uses_default_path_when_unset(caplog, monkeypatch):
+    """If stats are enabled but no path override is set, the default
+    ``~/.local/share/git-cai/stats.db`` is logged."""
+    from git_cai_cli.main import _log_stats_state
+
+    caplog.set_level("INFO")
+    _log_stats_state({"stats": True})
+
+    assert "Stats writing enabled" in caplog.text
+    assert "stats.db" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Stats wiring must be consistent across all modes (commit / squash / PR)
+# ---------------------------------------------------------------------------
+
+
+def test_squash_logs_stats_state(monkeypatch, caplog, tmp_path):
+    """`git cai -s` must log the stats state and DB path just like
+    `git cai`. Regression for the bug where squash silently bypassed
+    the stats log line."""
+    from git_cai_cli.core import squash as squash_module
+
+    config = {
+        "default": "openai",
+        "stats": True,
+        "stats_db_path": str(tmp_path / "x.db"),
+    }
+
+    monkeypatch.setattr(squash_module, "find_git_root", lambda: tmp_path)
+    monkeypatch.setattr(squash_module, "_is_shallow_clone", lambda: False)
+    monkeypatch.setattr(squash_module, "subprocess", squash_module.subprocess)
+
+    # Make every other thing return early after the log line — we just
+    # want to assert the stats state log fires.
+    monkeypatch.setattr(squash_module, "load_config", lambda: dict(config))
+    monkeypatch.setattr(squash_module, "apply_provider_overrides", lambda *a, **k: None)
+
+    def fake_check_output(cmd, **kwargs):
+        return ""
+
+    monkeypatch.setattr(squash_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(squash_module, "load_token", lambda config=None: "tok")
+
+    # After load_token, the rest of squash needs more mocks; raise to
+    # short-circuit since we've already passed the log point.
+    class _StopHere(Exception):
+        pass
+
+    def boom(*a, **kw):
+        raise _StopHere()
+
+    monkeypatch.setattr(squash_module, "CommitMessageGenerator", boom)
+
+    caplog.set_level("INFO")
+    try:
+        squash_module.squash_branch()
+    except _StopHere:
+        pass
+
+    assert "Stats writing enabled" in caplog.text
+    assert str(tmp_path / "x.db") in caplog.text
+
+
+def test_squash_sql_override_disables_writing(monkeypatch, tmp_path):
+    """`git cai -s --sql false` must override a persisted `stats: true`
+    just like the COMMIT path does."""
+    from git_cai_cli.core import squash as squash_module
+
+    captured_config = {}
+
+    monkeypatch.setattr(squash_module, "find_git_root", lambda: tmp_path)
+    monkeypatch.setattr(squash_module, "_is_shallow_clone", lambda: False)
+    monkeypatch.setattr(
+        squash_module,
+        "load_config",
+        lambda: {
+            "default": "openai",
+            "stats": True,
+            "stats_db_path": str(tmp_path / "x.db"),
+        },
+    )
+    monkeypatch.setattr(squash_module, "apply_provider_overrides", lambda *a, **k: None)
+
+    def fake_check_output(cmd, **kwargs):
+        return ""
+
+    monkeypatch.setattr(squash_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(squash_module, "load_token", lambda config=None: "tok")
+
+    class _StopHere(Exception):
+        pass
+
+    def capture_and_stop(token, config, provider, **kwargs):
+        captured_config["stats"] = config.get("stats")
+        raise _StopHere()
+
+    monkeypatch.setattr(squash_module, "CommitMessageGenerator", capture_and_stop)
+
+    try:
+        squash_module.squash_branch(sql_override=False)
+    except _StopHere:
+        pass
+
+    assert captured_config["stats"] is False
+
+
+def test_pr_logs_stats_state(monkeypatch, caplog, tmp_path):
+    """`git cai -r` must also log the stats state."""
+    from git_cai_cli.core import pr as pr_module
+
+    monkeypatch.setattr(pr_module, "find_git_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        pr_module,
+        "load_config",
+        lambda: {"default": "openai", "stats": False},
+    )
+    monkeypatch.setattr(pr_module, "apply_provider_overrides", lambda *a, **k: None)
+    monkeypatch.setattr(pr_module, "load_token", lambda config=None: "tok")
+
+    class _StopHere(Exception):
+        pass
+
+    monkeypatch.setattr(
+        pr_module, "detect_base_branch", lambda: (_ for _ in ()).throw(_StopHere())
+    )
+
+    caplog.set_level("INFO")
+    try:
+        pr_module.run_pr()
+    except (_StopHere, Exception):
+        pass
+
+    assert "Stats writing disabled" in caplog.text

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,9 +1,33 @@
+from unittest.mock import MagicMock
+
 import pytest
+import requests
 from git_cai_cli.core.validate import (
     _validate_config_keys,
     _validate_language,
+    _validate_llm_call,
     _validate_style,
 )
+
+
+def _make_http_error(status: int, body: dict | str | None) -> requests.HTTPError:
+    """Build a requests.HTTPError carrying a Response with the given body.
+
+    Tests only — never makes a real HTTP call.
+    """
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    if isinstance(body, dict):
+        resp.json.return_value = body
+        resp.text = ""
+    elif isinstance(body, str):
+        resp.json.side_effect = ValueError("not json")
+        resp.text = body
+    else:
+        resp.json.side_effect = ValueError("not json")
+        resp.text = ""
+    err = requests.HTTPError(f"{status} error", response=resp)
+    return err
 
 
 def test_validate_config_keys_valid_minimal(caplog):
@@ -77,6 +101,68 @@ def test_validate_config_keys_missing_globals_info(caplog):
 
     assert "Config does not define:" in caplog.text
     assert "Global or default values will be used" in caplog.text
+
+
+def test_validate_config_keys_does_not_complain_about_stats_db_path(caplog):
+    """``stats_db_path`` is an internal escape-hatch — accepted if set
+    but never reported as "missing" since users aren't expected to
+    define it (the default DB path is always the same)."""
+    caplog.set_level("INFO")
+
+    reference = {
+        "openai": {},
+        "language": "en",
+        "default": "openai",
+        "style": "professional",
+        "emoji": True,
+    }
+    # Define every documented top-level key so the only thing absent
+    # from the validator's set is ``stats_db_path``.
+    config = {
+        "openai": {"model": "gpt", "temperature": 0},
+        "language": "en",
+        "default": "openai",
+        "style": "professional",
+        "emoji": True,
+        "branch_context": False,
+        "conventional": False,
+        "load_tokens_from": None,
+        "prompt_file": "",
+        "squash_prompt_file": "",
+        "full_files_prompt_file": "",
+        "token_logging": False,
+        "measure_time": False,
+        "timeout": 30,
+        "full_files": False,
+        "pr_to_file": False,
+        "pr_file_name": "PR.md",
+        "pr_prompt_file": "",
+        "stats": False,
+    }
+
+    _validate_config_keys(config, reference)
+
+    assert "stats_db_path" not in caplog.text
+
+
+def test_validate_config_keys_accepts_stats_db_path_when_set(caplog):
+    """Setting ``stats_db_path`` is still allowed (e.g. tests use it) —
+    it must not be rejected as an unknown key."""
+    caplog.set_level("INFO")
+
+    reference = {
+        "openai": {},
+        "language": "en",
+        "default": "openai",
+        "style": "professional",
+        "emoji": True,
+    }
+    config = {
+        "openai": {"model": "gpt", "temperature": 0},
+        "stats_db_path": "/tmp/x.db",
+    }
+
+    _validate_config_keys(config, reference)  # must not raise
 
 
 def test_validate_config_keys_no_providers():
@@ -446,3 +532,144 @@ def test_old_config_missing_timeout_and_full_files_loads_cleanly(caplog):
 
     assert "timeout" in caplog.text
     assert "full_files" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _validate_llm_call — F0.1: status-code based error classification
+# ---------------------------------------------------------------------------
+
+
+def test_validate_llm_call_missing_token_raises():
+    """Missing token short-circuits before the function is invoked."""
+    with pytest.raises(ValueError, match="API token is missing"):
+        _validate_llm_call(lambda: "ok", token=None)
+
+
+def test_validate_llm_call_token_not_required_runs_callable():
+    """Token-less providers (e.g. Ollama) must pass through."""
+    result = _validate_llm_call(lambda: "ok", token=None, requires_token=False)
+    assert result == "ok"
+
+
+def test_validate_llm_call_passes_through_args():
+    """Positional and keyword args reach the wrapped callable."""
+
+    def fn(a, *, b):
+        return f"{a}-{b}"
+
+    result = _validate_llm_call(fn, "x", token="t", b="y")
+    assert result == "x-y"
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_validate_llm_call_auth_status_raises_clear_value_error(status):
+    """401/403 must classify as auth and surface the upstream message."""
+    err = _make_http_error(status, {"error": {"message": "invalid api key"}})
+
+    def fn():
+        raise err
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="bad")
+
+    assert str(status) in str(exc_info.value)
+    assert "invalid api key" in str(exc_info.value)
+
+
+def test_validate_llm_call_rate_limit_status_raises_clear_message():
+    """429 must classify as rate-limit, not auth."""
+    err = _make_http_error(429, {"error": {"message": "too many requests"}})
+
+    def fn():
+        raise err
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="t")
+
+    assert "Rate limit exceeded" in str(exc_info.value)
+    assert "429" in str(exc_info.value)
+    assert "too many requests" in str(exc_info.value)
+
+
+def test_validate_llm_call_400_is_not_misclassified_as_auth():
+    """The old substring matcher misclassified 400 as auth — it must not anymore."""
+    err = _make_http_error(400, {"error": {"message": "malformed request"}})
+
+    def fn():
+        raise err
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="t")
+
+    msg = str(exc_info.value)
+    assert "authentication" not in msg.lower()
+    assert "invalid or not authorized" not in msg.lower()
+    assert "400" in msg
+    assert "malformed request" in msg
+
+
+def test_validate_llm_call_5xx_raises_with_upstream_message():
+    err = _make_http_error(503, {"error": {"message": "service unavailable"}})
+
+    def fn():
+        raise err
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="t")
+
+    assert "503" in str(exc_info.value)
+    assert "service unavailable" in str(exc_info.value)
+
+
+def test_validate_llm_call_handles_non_json_body():
+    """Some providers (e.g. nginx 502) return HTML — must not crash."""
+    err = _make_http_error(502, "<html>bad gateway</html>")
+
+    def fn():
+        raise err
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="t")
+
+    assert "502" in str(exc_info.value)
+
+
+def test_validate_llm_call_openai_sdk_auth_error_classifies_as_auth():
+    """An exception with a status_code of 401 (OpenAI SDK style) is
+    classified as auth even when it is not requests.HTTPError."""
+
+    class FakeOpenAIAuthError(Exception):
+        status_code = 401
+
+    def fn():
+        raise FakeOpenAIAuthError("Incorrect API key provided")
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="t")
+
+    assert "401" in str(exc_info.value)
+    assert "invalid or not authorized" in str(exc_info.value)
+
+
+def test_validate_llm_call_openai_sdk_rate_limit_classifies_as_rate_limit():
+    class FakeOpenAIRateLimit(Exception):
+        status_code = 429
+
+    def fn():
+        raise FakeOpenAIRateLimit("rate limited")
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_llm_call(fn, token="t")
+
+    assert "Rate limit exceeded" in str(exc_info.value)
+    assert "429" in str(exc_info.value)
+
+
+def test_validate_llm_call_unrelated_exception_propagates():
+    """Non-HTTP, non-SDK errors must propagate (preserves stack for debug)."""
+
+    def fn():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _validate_llm_call(fn, token="t")

--- a/uv.lock
+++ b/uv.lock
@@ -313,6 +313,7 @@ name = "git-cai-cli"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },
+    { name = "pathspec" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "typer" },
@@ -329,6 +330,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "openai", specifier = ">=2.30.0" },
+    { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "typer", specifier = ">=0.23.1" },
@@ -671,6 +673,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- 🧭 Flatten statistics configuration and honor CLI overrides consistently so analytics behavior is easier to understand, validate, and inspect across all command paths.
- 📈 Expand generation event tracking with richer metadata, per-kind totals, and timing data to improve local usage visibility while preserving privacy-focused defaults.
- 🧹 Remove legacy stats migration behavior and rely on the current schema to avoid unnecessary data resets and reduce initialization complexity.
- ♻️ Refactor stats and session caching to reduce mutable global state, improve lazy initialization safety, and narrow error handling to expected non-fatal failures.
- 🧪 Update tests, help text, and related documentation to reflect the new defaults, internal config handling, and analytics behavior.

Replace the nested analytics configuration with a flatter model so settings are easier to read, validate, and override. This makes local statistics more approachable, surfaces the database path directly, and ensures temporary command-line settings behave predictably in commit, squash, and PR workflows.

Expand locally stored generation analytics to capture richer context, including repository metadata, prompt settings, event kind totals, and timing information. This improves the usefulness of usage reporting and the dedicated stats mode without changing generation behavior or sending data remotely.

Simplify stats initialization by removing legacy schema-version migration logic and treating older local-only data as disposable in an opt-in store. At the same time, reduce operational risk by replacing mutable caches with cached helpers, tightening exception handling, and preserving compatibility around stats state reporting.

Update tests and user-facing text to keep validation, defaults, and runtime behavior aligned with the refactor and expanded analytics coverage.