### PR TITLE
✨ Refactor request flow and persist scan exclusions

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -67,6 +67,7 @@ REPOSITORY_SEMGREP_RULESETS:
     "p/r2c-security-audit",
     "p/secure-defaults",
   ]
+SECURITY_SUGGESTIONS: false
 SHOW_ELAPSED_TIME: true
 SHOW_SKIPPED_LINTERS: true
 SPELL_PROSELINT_RULES_PATH: .linters

--- a/docs/git-cai.txt
+++ b/docs/git-cai.txt
@@ -914,7 +914,18 @@ Available configuration keys:
   credential formats are flagged (private keys, AWS/GitHub/Slack/Google/OpenAI
   keys); obvious placeholders (values containing `example`, `sample`, `dummy`,
   and repeated-character filler) are ignored. Local providers (Ollama) skip the
-  scan, since nothing leaves the machine.
+  scan, since nothing leaves the machine. When you confirm a flagged send in an
+  interactive commit (a false alarm), git-cai offers, per flagged file, to
+  remember the decision: add the file to `.caiignore` (drop it from git-cai
+  entirely), add it to `secret_scan_exclude` (keep sending it but skip its
+  scan), or skip (remember nothing).
+- `secret_scan_exclude` -- list of repo-relative paths whose contents are
+  exempt from the secret scan while still being sent to the LLM (default empty).
+  Use this for files that keep tripping a false positive (such as test fixtures)
+  but that you still want git-cai to see. Paths are matched with gitignore
+  semantics, like `.caiignore`, so directory patterns work too. The
+  false-alarm prompt writes here when you choose "keep, skip scan", targeting
+  the repository `cai_config.yml` if one exists, otherwise the home config.
 - `load_tokens_from` -- path to the tokens file
 - `prompt_file` -- path to the commit prompt Markdown file
 - `squash_prompt_file` -- path to the squash prompt Markdown file

--- a/docs/man/git-cai.1
+++ b/docs/man/git-cai.1
@@ -2,12 +2,12 @@
 .\"     Title: git-cai
 .\"    Author: Thorsten Foltz
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-06-19
+.\"      Date: 2026-06-24
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "GIT\-CAI" "1" "2026-06-19" "\ \&" "\ \&"
+.TH "GIT\-CAI" "1" "2026-06-24" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -1456,7 +1456,28 @@ match the send is blocked and you are asked to confirm (or pass
 credential formats are flagged (private keys, AWS/GitHub/Slack/Google/OpenAI
 keys); obvious placeholders (values containing \f(CRexample\fP, \f(CRsample\fP, \f(CRdummy\fP,
 and repeated\-character filler) are ignored. Local providers (Ollama) skip the
-scan, since nothing leaves the machine.
+scan, since nothing leaves the machine. When you confirm a flagged send in an
+interactive commit (a false alarm), git\-cai offers, per flagged file, to
+remember the decision: add the file to \f(CR.caiignore\fP (drop it from git\-cai
+entirely), add it to \f(CRsecret_scan_exclude\fP (keep sending it but skip its
+scan), or skip (remember nothing).
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\f(CRsecret_scan_exclude\fP \(em list of repo\-relative paths whose contents are
+exempt from the secret scan while still being sent to the LLM (default empty).
+Use this for files that keep tripping a false positive (such as test fixtures)
+but that you still want git\-cai to see. Paths are matched with gitignore
+semantics, like \f(CR.caiignore\fP, so directory patterns work too. The
+false\-alarm prompt writes here when you choose "keep, skip scan", targeting
+the repository \f(CRcai_config.yml\fP if one exists, otherwise the home config.
 .RE
 .sp
 .RS 4

--- a/src/git_cai_cli/core/config.py
+++ b/src/git_cai_cli/core/config.py
@@ -67,6 +67,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "stats": False,
     "signoff": False,
     "secret_scan": True,
+    "secret_scan_exclude": [],
 }
 
 # Providers that do not require an API token in tokens.yml
@@ -585,6 +586,43 @@ def set_config_value(key: str, raw_value: str, *, force_home: bool = False) -> P
     with target.open("w", encoding="utf-8") as f:
         yaml.safe_dump(_serialize_config(config), f, sort_keys=False)
 
+    return target
+
+
+def add_to_secret_scan_exclude(path: str, *, force_home: bool = False) -> Path:
+    """Append ``path`` to ``secret_scan_exclude`` in the active config file.
+
+    Targets the repo ``cai_config.yml`` if one exists, otherwise the home
+    config. Unlike :func:`set_config_value`, this never errors when no repo
+    config is present — it falls back to home, matching the "local if exists,
+    otherwise global" rule. The append is idempotent (dedup).
+
+    Returns the path to the config file that was written.
+    """
+    repo_config = None if force_home else _find_repo_config()
+    target = repo_config if repo_config else FALLBACK_CONFIG_FILE
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists() and target.stat().st_size > 0:
+        try:
+            with target.open("r", encoding="utf-8") as f:
+                config = cast(dict[str, Any], yaml.safe_load(f) or {})
+        except yaml.YAMLError as e:
+            raise ValueError(f"Failed to parse config file {target}: {e}") from e
+    else:
+        config = {}
+
+    existing = config.get("secret_scan_exclude")
+    if not isinstance(existing, list):
+        existing = []
+    if path not in existing:
+        existing.append(path)
+    config["secret_scan_exclude"] = existing
+
+    with target.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(_serialize_config(config), f, sort_keys=False)
+
+    log.info("Added %s to secret_scan_exclude in %s", path, target)
     return target
 
 

--- a/src/git_cai_cli/core/gitutils.py
+++ b/src/git_cai_cli/core/gitutils.py
@@ -222,6 +222,25 @@ def _load_caiignore_patterns(repo_root: Path) -> list[str]:
     return patterns
 
 
+def append_to_caiignore(repo_root: Path, path: str) -> Path:
+    """Append ``path`` as a line to ``<repo>/.caiignore`` if not already present.
+
+    Idempotent; creates the file if missing. Returns the ignore-file path.
+    """
+    ignore_file = repo_root / ".caiignore"
+    lines: list[str] = []
+    if ignore_file.exists():
+        lines = ignore_file.read_text(encoding="utf-8").splitlines()
+
+    if path in (line.strip() for line in lines):
+        return ignore_file
+
+    lines.append(path)
+    ignore_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    log.info("Added %s to %s", path, ignore_file)
+    return ignore_file
+
+
 def git_diff_excluding(
     repo_root: Path,
     run_cmd: Callable[..., subprocess.CompletedProcess] = subprocess.run,

--- a/src/git_cai_cli/core/llm.py
+++ b/src/git_cai_cli/core/llm.py
@@ -337,6 +337,51 @@ class CommitMessageGenerator:
         """
         self._classification_counts = classify_changed_paths(paths)
 
+    def _log_target(self) -> None:
+        """Log the active provider and model once, up front.
+
+        Call sites run this *before* starting the spinner so this routine
+        config noise does not interleave with the spinner's live frames —
+        interleaving would break the spinner line and make a single
+        generation look like two. The per-provider methods log the same
+        detail at DEBUG.
+        """
+        model = (self.config.get(self.default_model) or {}).get("model")
+        log.info("Using provider '%s' (model '%s').", self.default_model, model)
+
+    def send(self, content: str, system_prompt: str) -> str:
+        """Run the secret scan and dispatch a prebuilt request to the LLM.
+
+        This is the network-bound half of generation — the part worth
+        wrapping in a spinner. Prompt building (and its logging) happens
+        earlier in the matching ``build_*_request`` method.
+        """
+        return self._dispatch_generate(content=content, system_prompt=system_prompt)
+
+    def build_commit_request(
+        self,
+        git_diff: str,
+        context: str | None = None,
+        previous_message: str | None = None,
+    ) -> tuple[str, str]:
+        """Build the ``(content, system_prompt)`` pair for a commit message.
+
+        Split out from :meth:`generate` so prompt building runs before the
+        spinner starts. ``previous_message`` is used in amend mode.
+        """
+        self._log_target()
+        self.set_changed_files(paths_from_diff(git_diff))
+        prompt = self._build_commit_prompt(previous_message=previous_message)
+        log.debug("Commit system prompt preview: %r", prompt[:400])
+
+        content = git_diff
+        if context:
+            content = (
+                f"{git_diff}\n\n"
+                f"--- Additional context from the author ---\n{context}"
+            )
+        return content, prompt
+
     def generate(
         self,
         git_diff: str,
@@ -349,25 +394,16 @@ class CommitMessageGenerator:
         ``previous_message`` is used in amend mode so the model refines the
         existing message instead of regenerating from scratch.
         """
-        self.set_changed_files(paths_from_diff(git_diff))
-        prompt = self._build_commit_prompt(previous_message=previous_message)
-        log.debug("Commit system prompt preview: %r", prompt[:400])
+        content, prompt = self.build_commit_request(
+            git_diff, context=context, previous_message=previous_message
+        )
+        return self.send(content, prompt)
 
-        content = git_diff
-        if context:
-            content = (
-                f"{git_diff}\n\n"
-                f"--- Additional context from the author ---\n{context}"
-            )
-
-        return self._dispatch_generate(content=content, system_prompt=prompt)
-
-    def summarize_commit_history(
+    def build_squash_request(
         self, commit_messages: str, context: str | None = None
-    ) -> str:
-        """
-        Summarize multiple commit messages into one high-level commit message.
-        """
+    ) -> tuple[str, str]:
+        """Build the ``(content, system_prompt)`` pair for a squash summary."""
+        self._log_target()
         prompt = self._build_squash_prompt()
         log.debug("Squash system prompt preview: %r", prompt[:400])
 
@@ -377,19 +413,25 @@ class CommitMessageGenerator:
                 f"{commit_messages}\n\n"
                 f"--- Additional context from the author ---\n{context}"
             )
+        return content, prompt
 
-        return self._dispatch_generate(content=content, system_prompt=prompt)
+    def summarize_commit_history(
+        self, commit_messages: str, context: str | None = None
+    ) -> str:
+        """
+        Summarize multiple commit messages into one high-level commit message.
+        """
+        content, prompt = self.build_squash_request(commit_messages, context=context)
+        return self.send(content, prompt)
 
-    def generate_pr_description(
+    def build_pr_request(
         self,
         commit_log: str,
         changed_files: str,
         context: str | None = None,
-    ) -> str:
-        """
-        Generate a Markdown Pull Request description from the commit log and
-        changed-files list of a feature branch.
-        """
+    ) -> tuple[str, str]:
+        """Build the ``(content, system_prompt)`` pair for a PR description."""
+        self._log_target()
         self.set_changed_files(changed_files.splitlines())
         prompt = self._build_pr_prompt()
         log.debug("PR system prompt preview: %r", prompt[:400])
@@ -402,14 +444,27 @@ class CommitMessageGenerator:
             changed_files.strip() or "(no files)",
         ]
         content = "\n".join(sections)
-
         if context:
             content = (
                 f"{content}\n\n"
                 f"--- Additional context from the author ---\n{context}"
             )
+        return content, prompt
 
-        return self._dispatch_generate(content=content, system_prompt=prompt)
+    def generate_pr_description(
+        self,
+        commit_log: str,
+        changed_files: str,
+        context: str | None = None,
+    ) -> str:
+        """
+        Generate a Markdown Pull Request description from the commit log and
+        changed-files list of a feature branch.
+        """
+        content, prompt = self.build_pr_request(
+            commit_log, changed_files, context=context
+        )
+        return self.send(content, prompt)
 
     def _emoji_instruction(self) -> str:
         """
@@ -686,9 +741,24 @@ class CommitMessageGenerator:
         if self.default_model in TOKENLESS_PROVIDERS:
             return
 
-        from git_cai_cli.core.secrets import SecretLeakError, scan_for_secrets
+        from git_cai_cli.core.secrets import (
+            SecretLeakError,
+            drop_excluded,
+            scan_for_secrets,
+        )
 
         findings = scan_for_secrets(content)
+
+        # Files listed in `secret_scan_exclude` stay part of the payload but
+        # are exempt from the scan (false alarms the user already vetted).
+        # Matched with gitignore semantics for parity with `.caiignore`.
+        excludes = self.config.get("secret_scan_exclude") or []
+        if findings and excludes:
+            import pathspec
+
+            spec = pathspec.GitIgnoreSpec.from_lines(excludes)
+            findings = drop_excluded(findings, spec.match_file)
+
         if findings:
             raise SecretLeakError(findings)
 
@@ -714,7 +784,7 @@ class CommitMessageGenerator:
         if self.default_model not in model_dispatch:
             raise ValueError(f"Unknown model type: '{self.default_model}'")
 
-        log.info("Using provider '%s' for generation.", self.default_model)
+        log.debug("Using provider '%s' for generation.", self.default_model)
 
         return model_dispatch[self.default_model](
             content, system_prompt_override=system_prompt
@@ -751,7 +821,7 @@ class CommitMessageGenerator:
             or anthropic_cfg.get("max_tokens", 32768)
         )
 
-        log.info("Using anthropic model '%s'.", model)
+        log.debug("Using anthropic model '%s'.", model)
 
         # Anthropic Messages API expects system prompt via the top-level "system" field.
         messages = [{"role": "user", "content": content}]
@@ -817,7 +887,7 @@ class CommitMessageGenerator:
         model = self.config["gemini"]["model"]
         temperature = self.config["gemini"]["temperature"]
 
-        log.info("Using gemini model '%s'.", model)
+        log.debug("Using gemini model '%s'.", model)
 
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
 
@@ -874,7 +944,7 @@ class CommitMessageGenerator:
         model = self.config["groq"]["model"]
         temperature = self.config["groq"]["temperature"]
 
-        log.info("Using groq model '%s'.", model)
+        log.debug("Using groq model '%s'.", model)
 
         messages = []
 
@@ -934,7 +1004,7 @@ class CommitMessageGenerator:
         model = self.config["mistral"]["model"]
         temperature = self.config["mistral"]["temperature"]
 
-        log.info("Using mistral model '%s'.", model)
+        log.debug("Using mistral model '%s'.", model)
 
         messages = []
 
@@ -1119,7 +1189,7 @@ class CommitMessageGenerator:
         model = self.config["ollama"]["model"]
         temperature = self.config["ollama"]["temperature"]
 
-        log.info("Using ollama model '%s'.", model)
+        log.debug("Using ollama model '%s'.", model)
 
         url = f"{self._ollama_base_url()}/api/chat"
 
@@ -1214,7 +1284,7 @@ class CommitMessageGenerator:
             else self.config["openai"]["temperature"]
         )
 
-        log.info("Using %s model '%s'.", provider_name, model)
+        log.debug("Using %s model '%s'.", provider_name, model)
 
         messages = []
 
@@ -1265,7 +1335,7 @@ class CommitMessageGenerator:
         model = self.config["xai"]["model"]
         temperature = self.config["xai"]["temperature"]
 
-        log.info("Using xai model '%s'.", model)
+        log.debug("Using xai model '%s'.", model)
 
         messages = []
 

--- a/src/git_cai_cli/core/pr.py
+++ b/src/git_cai_cli/core/pr.py
@@ -150,14 +150,16 @@ def run_pr(
     generator.kind = "pr"
     generator.repo = repo_name_from_root(repo_root)
     generator.allow_secrets = allow_secrets
+    content, system_prompt = generator.build_pr_request(
+        commit_log, changed_files, context=context
+    )
     try:
         try:
             with Spinner("Generating PR description"):
                 description = _validate_llm_call(
-                    generator.generate_pr_description,
-                    commit_log,
-                    changed_files,
-                    context=context,
+                    generator.send,
+                    content,
+                    system_prompt,
                     token=token,
                     requires_token=provider not in TOKENLESS_PROVIDERS,
                 )

--- a/src/git_cai_cli/core/secrets.py
+++ b/src/git_cai_cli/core/secrets.py
@@ -9,7 +9,7 @@ ceiling. Swap in gitleaks/detect-secrets only if the FP rate becomes a problem.
 """
 
 import re
-from typing import NamedTuple
+from typing import Callable, NamedTuple
 
 
 class Finding(NamedTuple):
@@ -142,6 +142,18 @@ def scan_for_secrets(text: str) -> list[Finding]:
             seen.add(key)
             findings.append(Finding(rule, current_file, report_line, _mask(value)))
     return findings
+
+
+def drop_excluded(
+    findings: list[Finding], is_excluded: Callable[[str], bool]
+) -> list[Finding]:
+    """Drop findings whose file path is excluded from secret scanning.
+
+    ``is_excluded`` is a predicate over a path (the caller supplies the
+    matching semantics — see ``secret_scan_exclude``). Findings with no path
+    (``path is None``) are unattributable and never excluded.
+    """
+    return [f for f in findings if f.path is None or not is_excluded(f.path)]
 
 
 def format_findings(findings: list[Finding]) -> str:

--- a/src/git_cai_cli/core/squash.py
+++ b/src/git_cai_cli/core/squash.py
@@ -308,11 +308,13 @@ def squash_branch(
             start = time.perf_counter() if measure else None
 
             generator.kind = "commit"
+            content, system_prompt = generator.build_commit_request(diff)
             try:
                 with Spinner("Generating commit message for staged changes"):
                     msg = _validate_llm_call(
-                        generator.generate,
-                        diff,
+                        generator.send,
+                        content,
+                        system_prompt,
                         token=token,
                         requires_token=provider not in TOKENLESS_PROVIDERS,
                     )
@@ -395,12 +397,15 @@ def squash_branch(
         start = time.perf_counter() if measure else None
 
         generator.kind = "squash"
+        content, system_prompt = generator.build_squash_request(
+            commit_log, context=context
+        )
         try:
             with Spinner("Summarizing commit history"):
                 summary_message = _validate_llm_call(
-                    generator.summarize_commit_history,
-                    commit_log,
-                    context=context,
+                    generator.send,
+                    content,
+                    system_prompt,
                     token=token,
                     requires_token=provider not in TOKENLESS_PROVIDERS,
                 )

--- a/src/git_cai_cli/core/validate.py
+++ b/src/git_cai_cli/core/validate.py
@@ -73,10 +73,11 @@ def _validate_config_keys(config: dict[str, Any], reference: dict[str, Any]) -> 
         "stats_db_path",
         "signoff",
         "secret_scan",
+        "secret_scan_exclude",
     }
     # Internal escape-hatch keys: accepted if a user sets them, but never
     # reported as "missing" — they aren't part of the documented surface.
-    internal_only_keys = {"stats_db_path"}
+    internal_only_keys = {"stats_db_path", "secret_scan_exclude"}
     allowed_provider_keys = set(reference.keys()) - allowed_global_keys
 
     config_keys = set(config.keys())

--- a/src/git_cai_cli/main.py
+++ b/src/git_cai_cli/main.py
@@ -63,6 +63,50 @@ def _log_stats_state(config: dict) -> None:
     stats_module.log_state(config)
 
 
+def _route_false_alarm(findings: list, repo_root: Path | None) -> None:
+    """After a confirmed false alarm, offer to remember each flagged file.
+
+    For each distinct flagged path, prompt whether to add it to ``.caiignore``
+    (drop the file from git-cai), to ``secret_scan_exclude`` in the active
+    config (keep the file but skip its scan), or skip (remember nothing).
+    Findings without a path are unattributable and skipped.
+    """
+    from git_cai_cli.core.config import add_to_secret_scan_exclude
+    from git_cai_cli.core.gitutils import append_to_caiignore
+
+    seen: set[str] = set()
+    for finding in findings:
+        path = finding.path
+        if not path or path in seen:
+            continue
+        seen.add(path)
+
+        typer.echo(f"\nFalse alarm for: {path}", err=True)
+        typer.echo("How should git-cai remember this file?", err=True)
+        typer.echo(
+            "  1) .caiignore — drop the file from git-cai entirely "
+            "(it is never sent to the LLM again)",
+            err=True,
+        )
+        typer.echo(
+            "  2) config — keep sending the file, but skip its secret scan "
+            "from now on (added to secret_scan_exclude)",
+            err=True,
+        )
+        typer.echo("  3) skip — send it this once; remember nothing", err=True)
+        choice = typer.prompt("Choose", default="3").strip()
+
+        if choice == "1":
+            if repo_root is None:
+                typer.echo("Not in a git repo; cannot write .caiignore.", err=True)
+                continue
+            target = append_to_caiignore(repo_root, path)
+            typer.echo(f"Added {path} to {target}", err=True)
+        elif choice == "2":
+            target = add_to_secret_scan_exclude(path)
+            typer.echo(f"Added {path} to secret_scan_exclude in {target}", err=True)
+
+
 def run(
     *,
     mode: Mode,
@@ -272,15 +316,19 @@ def run(
     spinner_text = (
         "Regenerating commit message" if is_amend else "Generating commit message"
     )
+    # Build the prompt (and emit its config logging) before the spinner starts,
+    # so that routine info does not interleave with the live spinner frames.
+    content, system_prompt = generator.build_commit_request(
+        diff, context=context, previous_message=previous_message
+    )
     try:
         while True:
             try:
                 with Spinner(spinner_text):
                     commit_message = _validate_llm_call(
-                        generator.generate,
-                        diff,
-                        context=context,
-                        previous_message=previous_message,
+                        generator.send,
+                        content,
+                        system_prompt,
                         token=token,
                         requires_token=provider not in TOKENLESS_PROVIDERS,
                     )
@@ -299,6 +347,7 @@ def run(
                 ):
                     typer.echo("Aborted. Nothing was sent.", err=True)
                     raise typer.Exit(code=1)
+                _route_false_alarm(leak.findings, repo_root)
                 generator.allow_secrets = True
             except ValueError as e:
                 typer.echo(f"Error: {e}", err=True)

--- a/tests/integration/test_pr_integration.py
+++ b/tests/integration/test_pr_integration.py
@@ -71,7 +71,7 @@ def test_pr_writes_to_stdout_by_default(feature_branch_repo, capsys):
         patch("git_cai_cli.core.pr.load_config", return_value=cfg),
         patch("git_cai_cli.core.pr.load_token", return_value="token"),
         patch(
-            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            "git_cai_cli.core.llm.CommitMessageGenerator.send",
             return_value="## Summary\n- added src\n\n## Test plan\n- [ ] run",
         ),
     ):
@@ -90,7 +90,7 @@ def test_pr_writes_to_file_when_pr_to_file_true(feature_branch_repo):
         patch("git_cai_cli.core.pr.load_config", return_value=cfg),
         patch("git_cai_cli.core.pr.load_token", return_value="token"),
         patch(
-            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            "git_cai_cli.core.llm.CommitMessageGenerator.send",
             return_value="## Summary\n- added src",
         ),
     ):
@@ -108,7 +108,7 @@ def test_pr_respects_custom_pr_file_name(feature_branch_repo):
         patch("git_cai_cli.core.pr.load_config", return_value=cfg),
         patch("git_cai_cli.core.pr.load_token", return_value="token"),
         patch(
-            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            "git_cai_cli.core.llm.CommitMessageGenerator.send",
             return_value="BODY",
         ),
     ):
@@ -129,7 +129,7 @@ def test_pr_no_commits_does_nothing(feature_branch_repo, capsys, caplog):
         patch("git_cai_cli.core.pr.load_config", return_value=cfg),
         patch("git_cai_cli.core.pr.load_token", return_value="token"),
         patch(
-            "git_cai_cli.core.llm.CommitMessageGenerator.generate_pr_description",
+            "git_cai_cli.core.llm.CommitMessageGenerator.send",
             side_effect=AssertionError("should not be called"),
         ),
     ):

--- a/tests/unit/test_gitutils.py
+++ b/tests/unit/test_gitutils.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from git_cai_cli.core.gitutils import (
+    append_to_caiignore,
     collect_staged_file_contents,
     commit_with_edit_template,
     find_git_root,
@@ -27,6 +28,32 @@ from git_cai_cli.core.gitutils import (
     sha256_of_file,
     truncate_diff,
 )
+
+# ------------------------------------------------------------------------------
+# append_to_caiignore
+# ------------------------------------------------------------------------------
+
+
+def test_append_to_caiignore_creates_file(tmp_path):
+    result = append_to_caiignore(tmp_path, "tests/f.py")
+    assert result == tmp_path / ".caiignore"
+    assert (tmp_path / ".caiignore").read_text().splitlines() == ["tests/f.py"]
+
+
+def test_append_to_caiignore_is_idempotent(tmp_path):
+    append_to_caiignore(tmp_path, "tests/f.py")
+    append_to_caiignore(tmp_path, "tests/f.py")
+    assert (tmp_path / ".caiignore").read_text().splitlines() == ["tests/f.py"]
+
+
+def test_append_to_caiignore_preserves_existing(tmp_path):
+    (tmp_path / ".caiignore").write_text("existing.py\n")
+    append_to_caiignore(tmp_path, "new.py")
+    assert (tmp_path / ".caiignore").read_text().splitlines() == [
+        "existing.py",
+        "new.py",
+    ]
+
 
 # ------------------------------------------------------------------------------
 # truncate_diff

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,10 +2,13 @@
 Unit tests for provider override logic in git_cai_cli.core.config.
 """
 
+from unittest.mock import patch
+
 import pytest
 import typer
 from git_cai_cli.core.config import KNOWN_PROVIDERS, apply_provider_overrides
-from git_cai_cli.main import _relpaths_from_repo
+from git_cai_cli.core.secrets import Finding
+from git_cai_cli.main import _relpaths_from_repo, _route_false_alarm
 
 # ------------------------------------------
 # Tests for apply_provider_overrides
@@ -118,6 +121,77 @@ def test_relpaths_from_repo_keeps_paths_outside_repo(tmp_path):
     outside = tmp_path.parent / "other" / "thing.py"
     rels = _relpaths_from_repo(tmp_path, [str(outside)])
     assert rels == [str(outside)]
+
+
+# ------------------------------------------
+# Tests for _route_false_alarm
+# ------------------------------------------
+
+
+def _finding(path):
+    return Finding("AWS access key", path, 1, "AK…VD")
+
+
+def test_route_false_alarm_config_choice(tmp_path):
+    with (
+        patch("typer.prompt", return_value="2"),
+        patch("git_cai_cli.core.config.add_to_secret_scan_exclude") as add_cfg,
+        patch("git_cai_cli.core.gitutils.append_to_caiignore") as add_ign,
+    ):
+        _route_false_alarm([_finding("tests/f.py")], tmp_path)
+
+    add_cfg.assert_called_once_with("tests/f.py")
+    add_ign.assert_not_called()
+
+
+def test_route_false_alarm_caiignore_choice(tmp_path):
+    with (
+        patch("typer.prompt", return_value="1"),
+        patch("git_cai_cli.core.config.add_to_secret_scan_exclude") as add_cfg,
+        patch("git_cai_cli.core.gitutils.append_to_caiignore") as add_ign,
+    ):
+        _route_false_alarm([_finding("tests/f.py")], tmp_path)
+
+    add_ign.assert_called_once_with(tmp_path, "tests/f.py")
+    add_cfg.assert_not_called()
+
+
+def test_route_false_alarm_skip_choice_records_nothing(tmp_path):
+    with (
+        patch("typer.prompt", return_value="3"),
+        patch("git_cai_cli.core.config.add_to_secret_scan_exclude") as add_cfg,
+        patch("git_cai_cli.core.gitutils.append_to_caiignore") as add_ign,
+    ):
+        _route_false_alarm([_finding("tests/f.py")], tmp_path)
+
+    add_cfg.assert_not_called()
+    add_ign.assert_not_called()
+
+
+def test_route_false_alarm_skips_pathless_findings(tmp_path):
+    with (
+        patch("typer.prompt") as prompt,
+        patch("git_cai_cli.core.config.add_to_secret_scan_exclude") as add_cfg,
+        patch("git_cai_cli.core.gitutils.append_to_caiignore") as add_ign,
+    ):
+        _route_false_alarm([_finding(None)], tmp_path)
+
+    prompt.assert_not_called()
+    add_cfg.assert_not_called()
+    add_ign.assert_not_called()
+
+
+def test_route_false_alarm_prompts_once_per_distinct_path(tmp_path):
+    findings = [_finding("tests/f.py"), _finding("tests/f.py")]
+    with (
+        patch("typer.prompt", return_value="2") as prompt,
+        patch("git_cai_cli.core.config.add_to_secret_scan_exclude") as add_cfg,
+        patch("git_cai_cli.core.gitutils.append_to_caiignore"),
+    ):
+        _route_false_alarm(findings, tmp_path)
+
+    assert prompt.call_count == 1
+    add_cfg.assert_called_once_with("tests/f.py")
 
 
 def test_known_providers_set_is_complete():

--- a/tests/unit/test_pr.py
+++ b/tests/unit/test_pr.py
@@ -205,9 +205,8 @@ def test_run_pr_writes_to_stdout_by_default(mock_repo_root, base_config, capsys)
         raise AssertionError(f"unexpected cmd: {cmd}")
 
     gen = MagicMock()
-    gen.generate_pr_description.return_value = (
-        "## Summary\n- did stuff\n\n## Test plan\n- [ ] check"
-    )
+    gen.build_pr_request.return_value = ("content", "prompt")
+    gen.send.return_value = "## Summary\n- did stuff\n\n## Test plan\n- [ ] check"
 
     with (
         patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
@@ -240,7 +239,8 @@ def test_run_pr_writes_to_file_when_configured(mock_repo_root, base_config):
         raise AssertionError(f"unexpected cmd: {cmd}")
 
     gen = MagicMock()
-    gen.generate_pr_description.return_value = "## Summary\n- ok"
+    gen.build_pr_request.return_value = ("content", "prompt")
+    gen.send.return_value = "## Summary\n- ok"
 
     with (
         patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
@@ -271,7 +271,8 @@ def test_run_pr_uses_explicit_base_override(mock_repo_root, base_config, capsys)
         raise AssertionError(f"unexpected cmd: {cmd}")
 
     gen = MagicMock()
-    gen.generate_pr_description.return_value = "BODY"
+    gen.build_pr_request.return_value = ("content", "prompt")
+    gen.send.return_value = "BODY"
 
     with (
         patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),
@@ -308,7 +309,8 @@ def test_run_pr_classifies_auth_error(mock_repo_root, base_config, caplog):
     resp.json.return_value = {"error": {"message": "bad key"}}
 
     gen = MagicMock()
-    gen.generate_pr_description.side_effect = requests.HTTPError(response=resp)
+    gen.build_pr_request.return_value = ("content", "prompt")
+    gen.send.side_effect = requests.HTTPError(response=resp)
 
     with (
         patch("git_cai_cli.core.pr.find_git_root", return_value=mock_repo_root),

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 import pytest
 from git_cai_cli.core.llm import CommitMessageGenerator
 from git_cai_cli.core.secrets import (
+    Finding,
     SecretLeakError,
+    drop_excluded,
     format_findings,
     scan_for_secrets,
 )
@@ -117,4 +119,69 @@ def test_tokenless_provider_skips_gate():
     gen = _gen(default_model="ollama")
     with patch.object(gen, "generate_ollama", return_value="ok") as mock_fn:
         assert gen._dispatch_generate(SECRET_DIFF, "prompt") == "ok"
+    mock_fn.assert_called_once()
+
+
+# ---- drop_excluded ----
+
+
+def test_drop_excluded_removes_matching_paths():
+    f = Finding("AWS access key", "tests/fixtures/fake.py", 1, "AK…VD")
+    assert drop_excluded([f], lambda p: p == "tests/fixtures/fake.py") == []
+
+
+def test_drop_excluded_keeps_non_matching():
+    f = Finding("AWS access key", "src/real.py", 1, "AK…VD")
+    assert drop_excluded([f], lambda p: p == "other") == [f]
+
+
+def test_drop_excluded_never_drops_pathless_findings():
+    f = Finding("AWS access key", None, None, "AK…VD")
+    assert drop_excluded([f], lambda p: True) == [f]
+
+
+# ---- secret_scan_exclude gating ----
+
+
+def test_excluded_file_lets_send_through():
+    # SECRET_DIFF is for file "x"; excluding it should unblock the send.
+    gen = _gen(secret_scan_exclude=["x"])
+    with patch.object(gen, "generate_openai", return_value="ok") as mock_fn:
+        assert gen._dispatch_generate(SECRET_DIFF, "prompt") == "ok"
+    mock_fn.assert_called_once()
+
+
+def test_exclude_honors_gitignore_directory_pattern():
+    diff = f"diff --git a/tests/f.py b/tests/f.py\n+{REAL_AWS}\n"
+    gen = _gen(secret_scan_exclude=["tests/"])
+    with patch.object(gen, "generate_openai", return_value="ok") as mock_fn:
+        assert gen._dispatch_generate(diff, "prompt") == "ok"
+    mock_fn.assert_called_once()
+
+
+def test_exclude_for_other_file_still_blocks():
+    gen = _gen(secret_scan_exclude=["other.py"])
+    with patch.object(gen, "generate_openai") as mock_fn:
+        with pytest.raises(SecretLeakError):
+            gen._dispatch_generate(SECRET_DIFF, "prompt")
+    mock_fn.assert_not_called()
+
+
+# ---- build/send split (logging happens before the spinner) ----
+
+
+def test_build_commit_request_logs_target_before_send(caplog):
+    gen = _gen()
+    with caplog.at_level("INFO"):
+        content, prompt = gen.build_commit_request("diff --git a/x b/x\n+ok\n")
+
+    assert isinstance(content, str) and isinstance(prompt, str)
+    # The provider/model line must be emitted by build (pre-spinner), not send.
+    assert "Using provider 'openai'" in caplog.text
+
+
+def test_send_delegates_to_dispatch():
+    gen = _gen()
+    with patch.object(gen, "generate_openai", return_value="ok") as mock_fn:
+        assert gen.send("clean content", "prompt") == "ok"
     mock_fn.assert_called_once()

--- a/tests/unit/test_set_config.py
+++ b/tests/unit/test_set_config.py
@@ -4,7 +4,11 @@ Unit tests for the --set / --set-home config CLI feature.
 
 import pytest
 import yaml
-from git_cai_cli.core.config import _parse_config_value, set_config_value
+from git_cai_cli.core.config import (
+    _parse_config_value,
+    add_to_secret_scan_exclude,
+    set_config_value,
+)
 
 # ----------------------
 # _parse_config_value
@@ -174,3 +178,76 @@ def test_set_raises_when_no_repo_config(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="No repository config found"):
         set_config_value("default", "anthropic")
+
+
+# ----------------------
+# add_to_secret_scan_exclude
+# ----------------------
+
+
+def test_exclude_targets_repo_config_when_exists(tmp_path, monkeypatch):
+    from git_cai_cli.core import config as config_module
+
+    repo_config = tmp_path / "cai_config.yml"
+    repo_config.write_text(yaml.safe_dump({"default": "groq"}))
+    home_config = tmp_path / "home_config.yml"
+    home_config.write_text(yaml.safe_dump({"default": "openai"}))
+
+    monkeypatch.setattr(config_module, "FALLBACK_CONFIG_FILE", home_config)
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: repo_config)
+
+    result = add_to_secret_scan_exclude("tests/f.py")
+
+    assert result == repo_config
+    assert yaml.safe_load(repo_config.read_text())["secret_scan_exclude"] == [
+        "tests/f.py"
+    ]
+    assert "secret_scan_exclude" not in yaml.safe_load(home_config.read_text())
+
+
+def test_exclude_falls_back_to_home_when_no_repo(tmp_path, monkeypatch):
+    from git_cai_cli.core import config as config_module
+
+    home_config = tmp_path / "home_config.yml"
+    home_config.write_text(yaml.safe_dump({"default": "openai"}))
+
+    monkeypatch.setattr(config_module, "FALLBACK_CONFIG_FILE", home_config)
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: None)
+
+    result = add_to_secret_scan_exclude("tests/f.py")
+
+    assert result == home_config
+    assert yaml.safe_load(home_config.read_text())["secret_scan_exclude"] == [
+        "tests/f.py"
+    ]
+
+
+def test_exclude_dedups(tmp_path, monkeypatch):
+    from git_cai_cli.core import config as config_module
+
+    repo_config = tmp_path / "cai_config.yml"
+    repo_config.write_text(
+        yaml.safe_dump({"default": "groq", "secret_scan_exclude": ["a.py"]})
+    )
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: repo_config)
+
+    add_to_secret_scan_exclude("a.py")
+
+    assert yaml.safe_load(repo_config.read_text())["secret_scan_exclude"] == ["a.py"]
+
+
+def test_exclude_appends_to_existing_list(tmp_path, monkeypatch):
+    from git_cai_cli.core import config as config_module
+
+    repo_config = tmp_path / "cai_config.yml"
+    repo_config.write_text(
+        yaml.safe_dump({"default": "groq", "secret_scan_exclude": ["a.py"]})
+    )
+    monkeypatch.setattr(config_module, "_find_repo_config", lambda: repo_config)
+
+    add_to_secret_scan_exclude("b.py")
+
+    assert yaml.safe_load(repo_config.read_text())["secret_scan_exclude"] == [
+        "a.py",
+        "b.py",
+    ]

--- a/tests/unit/test_squash.py
+++ b/tests/unit/test_squash.py
@@ -31,6 +31,15 @@ def mock_generator() -> MagicMock:
     Fixture that simulates a commit message generator.
     """
     gen = MagicMock()
+    # New API: callers build the request before the spinner, then `send` it.
+    # Dispatch the mocked result by content so both flows (staged-commit
+    # message and squash summary) return the right thing regardless of order.
+    gen.build_commit_request.return_value = ("commit-content", "commit-prompt")
+    gen.build_squash_request.return_value = ("squash-content", "squash-prompt")
+    gen.send.side_effect = lambda content, _prompt: (
+        "commit message" if content == "commit-content" else "squash summary"
+    )
+    # Legacy methods kept for any test that calls them directly.
     gen.generate.return_value = "commit message"
     gen.summarize_commit_history.return_value = "squash summary"
     return gen
@@ -105,7 +114,9 @@ def test_squash_classifies_auth_error(mock_repo_root, clean_git_state, caplog) -
     resp.json.return_value = {"error": {"message": "bad key"}}
 
     gen = MagicMock()
-    gen.summarize_commit_history.side_effect = requests.HTTPError(response=resp)
+    gen.build_commit_request.return_value = ("content", "prompt")
+    gen.build_squash_request.return_value = ("content", "prompt")
+    gen.send.side_effect = requests.HTTPError(response=resp)
 
     with (
         patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
@@ -443,7 +454,7 @@ def test_squash_branch_passes_context_to_generator(
     ):
         squash_branch(context="Closes #42")
 
-    call_args = mock_generator.summarize_commit_history.call_args
+    call_args = mock_generator.build_squash_request.call_args
     assert call_args[1].get("context") == "Closes #42"
 
 


### PR DESCRIPTION
- 🔄 Separate request preparation from dispatch to keep spinner output clean and make command flows easier to validate consistently
- 🔒 Remember confirmed secret-scan false alarms so trusted files do not repeatedly interrupt interactive workflows
- 🧭 Clarify false-alarm prompts and test formatting to improve readability, reduce ambiguity, and stay aligned with linting rules
- 📝 Update documentation to describe the new exclusion behavior and interactive prompt flow

Split LLM request construction from network submission behind a shared send path so commands can prepare prompts before starting spinner-driven generation. This reduces noisy log interleaving, keeps validation scoped to the network-bound portion of the workflow, and preserves consistent behavior across commit, squash, and PR flows.

Add persistent handling for secret-scan false alarms by allowing vetted files to be excluded from future scans without excluding them from LLM input. This helps avoid repeated interruptions for known-safe fixtures and similar files while still giving users a clear choice to ignore a file entirely when appropriate.

Simplify the false-alarm prompt with numbered, descriptive options so users can understand the impact of each choice more quickly. Also reduce lint noise and align formatting in prompts and tests to keep automated checks focused on actionable issues and maintain a consistent code style.