### PR TITLE
🐛 Handle force-push failures gracefully

### DIFF
--- a/.linters/.pylintrc
+++ b/.linters/.pylintrc
@@ -68,10 +68,10 @@ check-protected-access-in-special-methods=no
 [DESIGN]
 max-args=30                                # Max arguments per function
 max-attributes=12                          # Max attributes per class
-max-branches=30                            # Max branches per function
+max-branches=35                            # Max branches per function
 max-locals=80                              # Max locals per function
 max-returns=10                             # Max return statements per function
-max-statements=130                         # Max total statements per function
+max-statements=140                         # Max total statements per function
 max-public-methods=20                      # Max public methods per class
 min-public-methods=1                       # Min public methods per class
 max-nested-blocks=15                       # Max nesting depth

--- a/docs/man/git-cai.1
+++ b/docs/man/git-cai.1
@@ -2,12 +2,12 @@
 .\"     Title: git-cai
 .\"    Author: Thorsten Foltz
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2026-06-24
+.\"      Date: 2026-06-29
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "GIT\-CAI" "1" "2026-06-24" "\ \&" "\ \&"
+.TH "GIT\-CAI" "1" "2026-06-29" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/src/git_cai_cli/core/squash.py
+++ b/src/git_cai_cli/core/squash.py
@@ -484,8 +484,21 @@ def squash_branch(
             )
             choice = input("Shall I execute it for you now? [yes/no]: ").strip().lower()
             if choice in ("y", "yes"):
-                subprocess.run(["git", "push", "--force-with-lease"], check=True)
-                log.info("✅ Successfully pushed the squashed branch to remote.")
+                push_result = subprocess.run(
+                    ["git", "push", "--force-with-lease"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if push_result.returncode == 0:
+                    log.info("✅ Successfully pushed the squashed branch to remote.")
+                else:
+                    log.debug("git push failed:\n%s", push_result.stderr.strip())
+                    log.error(
+                        "❌ Push failed. The remote branch may have been merged and "
+                        "deleted.\nCheck whether the remote branch still exists "
+                        "(e.g. `git branch -r`), then push manually if needed."
+                    )
         else:
             log.info(
                 "No upstream branch detected. Normal `git push` will work as expected."

--- a/tests/unit/test_squash.py
+++ b/tests/unit/test_squash.py
@@ -267,7 +267,48 @@ def test_force_push_prompt_and_execution(
     ):
         squash_branch()
 
-    run_mock.assert_any_call(["git", "push", "--force-with-lease"], check=True)
+    run_mock.assert_any_call(
+        ["git", "push", "--force-with-lease"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_force_push_failure_is_handled(
+    mock_repo_root, clean_git_state, mock_generator, caplog
+) -> None:
+    """
+    Test that a failed force push is reported gracefully without raising.
+    """
+
+    def run_side_effect(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "push"]:
+            return MagicMock(returncode=1, stderr="! [rejected] (stale info)")
+        return MagicMock(returncode=0)
+
+    run_mock = MagicMock(side_effect=run_side_effect)
+
+    with (
+        patch("git_cai_cli.core.squash.find_git_root", return_value=mock_repo_root),
+        patch("subprocess.check_output", side_effect=clean_git_state),
+        patch(
+            "git_cai_cli.core.squash.load_config", return_value={"default": "openai"}
+        ),
+        patch("git_cai_cli.core.squash.load_token", return_value="token"),
+        patch(
+            "git_cai_cli.core.squash.CommitMessageGenerator",
+            return_value=mock_generator,
+        ),
+        patch("git_cai_cli.core.squash.get_git_editor", return_value="true"),
+        patch("git_cai_cli.core.squash.sha256_of_file", side_effect=["a", "b"]),
+        patch("subprocess.run", run_mock),
+        patch("git_cai_cli.core.squash._has_upstream", return_value=True),
+        patch.object(builtins, "input", return_value="yes"),
+    ):
+        squash_branch()
+
+    assert "Push failed" in caplog.text
 
 
 # --- Tests for new squash argument helpers ---


### PR DESCRIPTION
- 🛡️ Prevent squash operations from failing noisily when a protected force-push cannot be completed
- ✅ Improve test coverage to ensure push failures are reported through user-facing logging instead of exceptions
- 🔧 Adjust lint thresholds to reflect the expanded squash control flow without adding unnecessary noise
- 📝 Refresh documentation metadata to keep generated output current

Make squash recovery more resilient when `git push --force-with-lease` fails after rewriting history. Instead of raising an exception in cases where the remote branch was likely merged or deleted, report a clear error so users can understand what happened and recover manually.

Update the test suite to validate the non-raising failure path and preserve the expected user-facing behavior. Also relax lint limits to accommodate the added control flow, and refresh the generated man page metadata to keep documentation artifacts in sync.